### PR TITLE
Fix overuse of "example" in an example

### DIFF
--- a/url.html
+++ b/url.html
@@ -160,7 +160,7 @@ references the code point the <var title="">pointer</var> variable points to.
 <dfn id="remaining">remaining</dfn> references the substring after <var title="">pointer</var> in the string
 being processed.
 
-<p class="example">If "<code title="">mailto:example@example</code>" is a string being
+<p class="example">If "<code title="">mailto:username@example</code>" is a string being
 processed and <var title="">pointer</var> points to "<code title="">@</code>",
 <a href="#c">c</a> is "<code title="">@</code>" and <a href="#remaining">remaining</a> is
 "<code title="">example</code>".

--- a/url.src.html
+++ b/url.src.html
@@ -134,7 +134,7 @@ references the code point the <var title>pointer</var> variable points to.
 <dfn>remaining</dfn> references the substring after <var title>pointer</var> in the string
 being processed.
 
-<p class=example>If "<code title>mailto:example@example</code>" is a string being
+<p class=example>If "<code title>mailto:username@example</code>" is a string being
 processed and <var title>pointer</var> points to "<code title>@</code>",
 <span>c</span> is "<code title>@</code>" and <span>remaining</span> is
 "<code title>example</code>".


### PR DESCRIPTION
In the example for "remaining" value, the text "example@example" could be misleading. Using "username@example" makes it more clear.
