### PR TITLE
Adding URLs for RFCs

### DIFF
--- a/url.src.html
+++ b/url.src.html
@@ -45,7 +45,7 @@
 It does so as follows:
 
 <ul>
- <li><p>Align RFC 3986 and RFC 3987 with contemporary implementations and
+ <li><p>Align <a href="http://www.ietf.org/rfc/rfc3986.txt" target="ietf">RFC 3986</a> and <a href="http://www.ietf.org/rfc/rfc3987.txt" target="ietf">RFC 3987</a> with contemporary implementations and
  obsolete them in the process. (E.g. spaces, other "illegal" code points,
  query encoding, equality, canonicalization, are all concepts not entirely
  shared, or defined.) URL parsing needs to become as solid as HTML parsing.


### PR DESCRIPTION
Since the primary goal of this spec is to reconcile these two RFCs, being able to quickly link to the references is important. I was unable to locate any documentation referring to whether or not I should update the url.html file as well, and considering there's a makefile being utilized, I'm merely submitting the URL changes here to the src.html file.
