### PR TITLE
reorder to check for EOF before incrementing

### DIFF
--- a/url.html
+++ b/url.html
@@ -1600,7 +1600,7 @@ optionally with an <a class="external" data-anolis-spec="encoding" href="https:/
    <dd>
     <ol>
      <li>
-      <p>If <a href="#c">c</a> is the <a href="#eof-code-point">EOF code point</a> or
+      <p>If <a href="#c">c</a> is the <a href="#eof-code-point">EOF code point</a>, or
       <var title="">state override</var> is not given and <a href="#c">c</a>
       is "<code title="">#</code>", run these substeps:
 

--- a/url.src.html
+++ b/url.src.html
@@ -1567,7 +1567,7 @@ optionally with an <span data-anolis-spec=encoding>encoding</span>
    <dd>
     <ol>
      <li>
-      <p>If <span>c</span> is the <span>EOF code point</span> or
+      <p>If <span>c</span> is the <span>EOF code point</span>, or
       <var title>state override</var> is not given and <span>c</span>
       is "<code title>#</code>", run these substeps:
 


### PR DESCRIPTION
Clarify that the check for EOF is to be done prior to incrementing pointer.
