### PR TITLE
Reorder to check for EOF before incrementing

### DIFF
--- a/url.html
+++ b/url.html
@@ -9,7 +9,7 @@
 
 <hgroup>
  <h1 class="allcaps">URL</h1>
- <h2>Living Standard — Last Updated 7 October 2014</h2>
+ <h2>Living Standard — Last Updated 11 October 2014</h2>
 </hgroup>
 
 <dl>
@@ -1007,9 +1007,10 @@ optionally with an <a class="external" data-anolis-spec="encoding" href="https:/
 
  <li>
   <p>Keep running the following state machine by switching on
-  <var title="">state</var>, increasing <var title="">pointer</var> by one after
-  each time it is run, and if after a run <var title="">pointer</var> points to the
-  <a href="#eof-code-point">EOF code point</a>, go to the next step.
+  <var title="">state</var>.  If after a run <var title="">pointer</var> points
+  to the <a href="#eof-code-point">EOF code point</a>, go to the next step;
+  otherwise increase <var title="">pointer</var> by one and continue with the
+  state machine.
 
   <dl class="switch">
    <dt><dfn id="scheme-start-state">scheme start state</dfn>

--- a/url.src.html
+++ b/url.src.html
@@ -974,9 +974,10 @@ optionally with an <span data-anolis-spec=encoding>encoding</span>
 
  <li>
   <p>Keep running the following state machine by switching on
-  <var title>state</var>, increasing <var title>pointer</var> by one after
-  each time it is run, and if after a run <var title>pointer</var> points to the
-  <span>EOF code point</span>, go to the next step.
+  <var title="">state</var>.  If after a run <var title="">pointer</var> points
+  to the <a href="#eof-code-point">EOF code point</a>, go to the next step;
+  otherwise increase <var title="">pointer</var> by one and continue with the
+  state machine.
 
   <dl class=switch>
    <dt><dfn>scheme start state</dfn>


### PR DESCRIPTION
Clarify that the check for EOF is to be done prior to incrementing pointer.
