### PR TITLE
Link "ASCII hex digits" in IPv4 number parser to its definiton.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -12,6 +12,7 @@ Logo: https://resources.whatwg.org/logo-url.svg
 !Commits: <a href="https://github.com/whatwg/url/commits">https://github.com/whatwg/url/commits</a>
 !Commits: <a href="https://twitter.com/urlstandard">@urlstandard</a>
 Indent: 2
+Boilerplate: omit feedback-header
 </pre>
 
 <script src=https://resources.whatwg.org/file-issue.js async></script>
@@ -390,7 +391,7 @@ steps:
  <!-- XXX radix-R digit, hahaha, that's not a thing -->
 
  <li><p>Return the mathematical integer value that is represented by <var>input</var> in
- radix-<var>R</var> notation, using <span>ASCII hex digits</span> for digits with values 0
+ radix-<var>R</var> notation, using <a>ASCII hex digits</a> for digits with values 0
  through 15.
  <!-- XXX well, you know, it works for ECMAScript, kinda -->
 </ol>

--- a/url.html
+++ b/url.html
@@ -17,64 +17,6 @@
   
 
   <meta content="Bikeshed 1.0.0" name="generator">
-  <style>.highlight .hll { background-color: #ffffcc }
-.highlight  { background: #ffffff; }
-.highlight .c { color: #708090 } /* Comment */
-.highlight .k { color: #990055 } /* Keyword */
-.highlight .l { color: #669900 } /* Literal */
-.highlight .n { color: #0077aa } /* Name */
-.highlight .o { color: #999999 } /* Operator */
-.highlight .p { color: #999999 } /* Punctuation */
-.highlight .cm { color: #708090 } /* Comment.Multiline */
-.highlight .cp { color: #708090 } /* Comment.Preproc */
-.highlight .c1 { color: #708090 } /* Comment.Single */
-.highlight .cs { color: #708090 } /* Comment.Special */
-.highlight .kc { color: #990055 } /* Keyword.Constant */
-.highlight .kd { color: #990055 } /* Keyword.Declaration */
-.highlight .kn { color: #990055 } /* Keyword.Namespace */
-.highlight .kp { color: #990055 } /* Keyword.Pseudo */
-.highlight .kr { color: #990055 } /* Keyword.Reserved */
-.highlight .kt { color: #990055 } /* Keyword.Type */
-.highlight .ld { color: #669900 } /* Literal.Date */
-.highlight .m { color: #990055 } /* Literal.Number */
-.highlight .s { color: #669900 } /* Literal.String */
-.highlight .na { color: #0077aa } /* Name.Attribute */
-.highlight .nc { color: #0077aa } /* Name.Class */
-.highlight .no { color: #0077aa } /* Name.Constant */
-.highlight .nd { color: #0077aa } /* Name.Decorator */
-.highlight .ni { color: #0077aa } /* Name.Entity */
-.highlight .ne { color: #0077aa } /* Name.Exception */
-.highlight .nf { color: #0077aa } /* Name.Function */
-.highlight .nl { color: #0077aa } /* Name.Label */
-.highlight .nn { color: #0077aa } /* Name.Namespace */
-.highlight .py { color: #0077aa } /* Name.Property */
-.highlight .nt { color: #0077aa } /* Name.Tag */
-.highlight .nv { color: #0077aa } /* Name.Variable */
-.highlight .ow { color: #999999 } /* Operator.Word */
-.highlight .mb { color: #990055 } /* Literal.Number.Bin */
-.highlight .mf { color: #990055 } /* Literal.Number.Float */
-.highlight .mh { color: #990055 } /* Literal.Number.Hex */
-.highlight .mi { color: #990055 } /* Literal.Number.Integer */
-.highlight .mo { color: #990055 } /* Literal.Number.Oct */
-.highlight .sb { color: #669900 } /* Literal.String.Backtick */
-.highlight .sc { color: #669900 } /* Literal.String.Char */
-.highlight .sd { color: #669900 } /* Literal.String.Doc */
-.highlight .s2 { color: #669900 } /* Literal.String.Double */
-.highlight .se { color: #669900 } /* Literal.String.Escape */
-.highlight .sh { color: #669900 } /* Literal.String.Heredoc */
-.highlight .si { color: #669900 } /* Literal.String.Interpol */
-.highlight .sx { color: #669900 } /* Literal.String.Other */
-.highlight .sr { color: #669900 } /* Literal.String.Regex */
-.highlight .s1 { color: #669900 } /* Literal.String.Single */
-.highlight .ss { color: #669900 } /* Literal.String.Symbol */
-.highlight .vc { color: #0077aa } /* Name.Variable.Class */
-.highlight .vg { color: #0077aa } /* Name.Variable.Global */
-.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-.highlight .il { color: #990055 } /* Literal.Number.Integer.Long */
-    .highlight { background: hsl(24, 20%, 95%); }
-    pre.highlight { padding: 1em; margin: .5em 0; overflow: auto; }
-    :not(pre).highlight { padding: .1em; border-radius: .3em; }
-    </style>
  </head>
  <body class="h-entry status-LS">
 
@@ -705,7 +647,7 @@ steps:</p>
  </p>
     <li>
      <p>Return the mathematical integer value that is represented by <var>input</var> in
- radix-<var>R</var> notation, using <span>ASCII hex digits</span> for digits with values 0
+ radix-<var>R</var> notation, using <a data-link-type="dfn" href="#ascii-hex-digits">ASCII hex digits</a> for digits with values 0
  through 15.
  
 </p></ol>


### PR DESCRIPTION
(I think the `<style>` change is Bikeshed now doing syntax highlighting in python with Pygments rather than in JS with Prism.)