### PR TITLE
Avoid implicitly defined "in scope" concept

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -856,8 +856,8 @@ more of <a>ASCII alphanumeric</a>, "<code>+</code>", "<code>-</code>", and
 <a lt="URL scheme">scheme</a> and "<code>:</code>", optionally followed by a
 "<code>?</code>" and a <a lt="URL query">query</a>.
 
-<p>When a <a>relative URL</a> is <a lt="URL parser">parsed</a>, a <a>base URL</a> must be
-in scope.
+<p class="note no-backref">A non-null <a>base URL</a> is necessary when
+<a lt="URL parser">parsing</a> a <a>relative URL</a>.
 
 <p>A <dfn id=concept-scheme-relative-url>scheme-relative URL</dfn> must be
 "<code>//</code>", followed by a <a>host</a>, optionally followed by "<code>:</code>" and

--- a/url.html
+++ b/url.html
@@ -1374,8 +1374,8 @@ more of <a data-link-type="dfn" href="#ascii-alphanumeric">ASCII alphanumeric</a
 "<code>?</code>" and a <a data-link-type="dfn" href="#concept-url-query">query</a>.
 
 </p>
-   <p>When a <a data-link-type="dfn" href="#concept-relative-url">relative URL</a> is <a data-link-type="dfn" href="#concept-url-parser">parsed</a>, a <a data-link-type="dfn" href="#concept-base-url">base URL</a> must be
-in scope.
+   <p class="note no-backref" role="note">A non-null <a data-link-type="dfn" href="#concept-base-url">base URL</a> is necessary when
+<a data-link-type="dfn" href="#concept-url-parser">parsing</a> a <a data-link-type="dfn" href="#concept-relative-url">relative URL</a>.
 
 </p>
    <p>A <dfn data-dfn-type="dfn" data-noexport="" id="concept-scheme-relative-url">scheme-relative URL<a class="self-link" href="#concept-scheme-relative-url"></a></dfn> must be


### PR DESCRIPTION
~~(The whitespace-ignorant diff is easier to read)~~
This replaces the redundant "base URL must be in scope" requirement with a non-normative note ~~and an explicit *base-URL-is-null?* check in the *relative state* of the parsing algorithm.~~

This avoids an extraneous concept of scope ~~and further clarifies the behavior of the parser when the URL is relative but there is no base URL.~~