### PR TITLE
Link all of "application/x-www-form-urlencoded parsing" for clarity

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2335,7 +2335,7 @@ takes a list of name-value pairs <var>pairs</var>, optionally with an
 takes a string <var>input</var>,
 <a lt="utf-8 encode">utf-8 encodes</a> it, and then
 returns the result of
-<code lt=application-x-www-form-urlencoded-0><a lt='urlencoded parser'>application/x-www-form-urlencoded</a></code> parsing</a>
+<a lt='urlencoded parser'><code>application/x-www-form-urlencoded</code> parsing</a>
 it.
 
 
@@ -2873,6 +2873,7 @@ Michael Peick,
 Michael™ Smith,
 Michel Suignard,
 Peter Occil,
+Philip Jägenstedt,
 Rodney Rehm,
 Roy Fielding,
 Ryan Sleevi,

--- a/url.html
+++ b/url.html
@@ -11,7 +11,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-url.svg"> </a> </p>
    <h1 class="p-name no-ref allcaps" id="title">URL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-10-12">12 October 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-11-16">16 November 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Participate:
@@ -1676,8 +1676,7 @@ optionally with a <i title="">use _charset_ flag</i>, and optionally with an <i 
    </ol>
    <h3 class="heading settled" data-level="5.3" id="urlencoded-hooks"><span class="secno">5.3. </span><span class="content">Hooks</span><a class="self-link" href="#urlencoded-hooks"></a></h3>
    <p>The <dfn data-dfn-type="dfn" data-lt="urlencoded string parser" data-noexport="" id="concept-urlencoded-string-parser"><code data-lt="application-x-www-form-urlencoded-0"><a data-link-type="dfn" href="#application-x-www-form-urlencoded-0">application/x-www-form-urlencoded</a></code> string parser<a class="self-link" href="#concept-urlencoded-string-parser"></a></dfn> takes a string <var>input</var>, <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-encode">utf-8 encodes</a> it, and then
-returns the result of <code data-lt="application-x-www-form-urlencoded-0"><a data-link-type="dfn" href="#concept-urlencoded-parser">application/x-www-form-urlencoded</a></code> parsing
-it. </p>
+returns the result of <a data-link-type="dfn" href="#concept-urlencoded-parser"><code>application/x-www-form-urlencoded</code> parsing</a> it. </p>
    <h2 class="heading settled" data-level="6" id="api"><span class="secno">6. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
 <pre class="idl">[<a class="idl-code" data-link-type="constructor" href="#dom-url-url">Constructor</a>(USVString <dfn class="idl-code" data-dfn-for="URL/URL(url, base)" data-dfn-type="argument" data-export="" id="dom-url-url-url-base-url">url<a class="self-link" href="#dom-url-url-url-base-url"></a></dfn>, optional USVString <dfn class="idl-code" data-dfn-for="URL/URL(url, base)" data-dfn-type="argument" data-export="" id="dom-url-url-url-base-base">base<a class="self-link" href="#dom-url-url-url-base-base"></a></dfn>),
  Exposed=(Window,Worker)]
@@ -2055,6 +2054,7 @@ Michael Peick,
 Michael™ Smith,
 Michel Suignard,
 Peter Occil,
+Philip Jägenstedt,
 Rodney Rehm,
 Roy Fielding,
 Ryan Sleevi,


### PR DESCRIPTION
It was not obvious that application/x-www-form-urlencoded was a link
at all.

The markup had an extra </a>, suggesting this was originally intended.