### PR TITLE
Add a note in the URL parser.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1241,8 +1241,10 @@ optionally with an <a>encoding</a>
 
        <li><p>Otherwise, if <var>url</var> <a>is special</a>, <var>base</var> is non-null,
        and <var>base</var>'s <a for=url>scheme</a> is equal to <var>url</var>'s
-       <a for=url>scheme</a>, set <var>state</var> to
-       <a>special relative or authority state</a>.
+       <a for=url>scheme</a>
+       <span class=note>(this implies that <var>base</var>’s <a>non-relative flag</a>
+       is unset)</span>,
+       set <var>state</var> to <a>special relative or authority state</a>.
 
        <li><p>Otherwise, if <var>url</var> <a>is special</a>, set <var>state</var> to
        <a>special authority slashes state</a>.


### PR DESCRIPTION
When reading this part of the parser I first thought that it was possible to enter the relative state with a non-relative base URL, which would lead to instructions that don’t make much sense. I’m now convinced that is not possible, but the reason is subtle and worth noting.

I did not include regenerating `url.html` as the diff would be noisy, I seem to have a different version of Bikeshed.