### PR TITLE
Rename non-relative to cannot-be-a-base-URL.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -844,8 +844,9 @@ resource the <a for=url>URL</a>'s other components identify. It is initially nul
 
 <p class="note no-backref">This is not an <a>ASCII string</a> on purpose.
 
-<p>A <a for=url>URL</a> also has an associated <dfn>non-relative flag</dfn>. It is
-initially unset.
+<p>A <a for=url>URL</a> also has an associated
+<dfn><span id=non-relative-flag>cannot-be-a-base-URL flag</span></dfn>.
+It is initially unset.
 
 <p>A <a for=url>URL</a> also has an associated
 <dfn export for=url id=concept-url-object>object</dfn> that is either null or a
@@ -1246,8 +1247,8 @@ optionally with an <a>encoding</a>
         <var>base</var>'s <a for=url>scheme</a> is equal to <var>url</var>'s <a for=url>scheme</a>,
         set <var>state</var> to <a>special relative or authority state</a>.
 
-        <p class="note no-backref">This means that <var>base</var>'s <a>non-relative flag</a> is
-        unset.
+        <p class="note no-backref">This means that <var>base</var>'s
+        <a>cannot-be-a-base-URL flag</a> is unset.
 
        <li><p>Otherwise, if <var>url</var> <a>is special</a>, set <var>state</var> to
        <a>special authority slashes state</a>.
@@ -1256,9 +1257,9 @@ optionally with an <a>encoding</a>
        <var>state</var> to <a>path or authority state</a>, and increase <var>pointer</var>
        by one.
 
-       <li><p>Otherwise, set <var>url</var>'s <a>non-relative flag</a>, append an empty
+       <li><p>Otherwise, set <var>url</var>'s <a>cannot-be-a-base-URL flag</a>, append an empty
        string to <var>url</var>'s <a for=url>path</a>, and set <var>state</var> to
-       <a>non-relative path state</a>.
+       <a>cannot-be-a-base-URL path state</a>.
       </ol>
 
      <li><p>Otherwise, if <var>state override</var> is not given, set
@@ -1272,10 +1273,10 @@ optionally with an <a>encoding</a>
    <dt><dfn>no scheme state</dfn>
    <dd>
     <ol>
-     <li><p>If <var>base</var> is null, or <var>base</var>'s <a>non-relative flag</a> is
+     <li><p>If <var>base</var> is null, or <var>base</var>'s <a>cannot-be-a-base-URL flag</a> is
      set and <a>c</a> is not "<code>#</code>", <a>syntax violation</a>, return failure.
 
-     <li><p>Otherwise, if <var>base</var>'s <a>non-relative flag</a> is set and <a>c</a>
+     <li><p>Otherwise, if <var>base</var>'s <a>cannot-be-a-base-URL flag</a> is set and <a>c</a>
      is "<code>#</code>", set <var>url</var>'s <a for=url>scheme</a> to
      <var>base</var>'s <a for=url>scheme</a>,
      <var>url</var>'s <a for=url>path</a> to
@@ -1283,7 +1284,7 @@ optionally with an <a>encoding</a>
      <var>url</var>'s <a for=url>query</a> to
      <var>base</var>'s <a for=url>query</a>,
      <var>url</var>'s <a for=url>fragment</a> to the empty string, set
-     <var>url</var>'s <a>non-relative flag</a>, and set <var>state</var> to
+     <var>url</var>'s <a>cannot-be-a-base-URL flag</a>, and set <var>state</var> to
      <a>fragment state</a>.
 
      <li><p>Otherwise, if <var>base</var>'s <a for=url>scheme</a> is not
@@ -1844,7 +1845,7 @@ optionally with an <a>encoding</a>
       </ol>
     </ol>
 
-   <dt><dfn>non-relative path state</dfn>
+   <dt><dfn>cannot-be-a-base-URL path state</dfn>
    <dd>
     <ol>
      <li><p>If <a>c</a> is "<code>?</code>", set <var>url</var>'s
@@ -2034,7 +2035,7 @@ then runs these steps:
  <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>", append
  "<code>//</code>" to <var>output</var>.
 
- <li><p>If <var>url</var>'s <a>non-relative flag</a> is set, append the first string in
+ <li><p>If <var>url</var>'s <a>cannot-be-a-base-URL flag</a> is set, append the first string in
  <var>url</var>'s <a for=url>path</a> to <var>output</var>.
 
  <li><p>Otherwise, append "<code>/</code>", followed by the strings in <var>url</var>'s
@@ -2538,7 +2539,7 @@ compatibility with HTML's <code>MessageEvent</code> feature. [[!HTML]]
 
 <ol>
  <li><p>If <a>context object</a>'s <a for=URL>url</a>'s <a for=url>host</a> is null, or its
- <a>non-relative flag</a> is set, terminate these steps.
+ <a>cannot-be-a-base-URL flag</a> is set, terminate these steps.
 
  <li><p><a>Set the username</a> given <a>context object</a>'s <a for=URL>url</a> and the given
  value.
@@ -2557,7 +2558,7 @@ compatibility with HTML's <code>MessageEvent</code> feature. [[!HTML]]
 
 <ol>
  <li><p>If <a>context object</a>'s <a for=URL>url</a>'s <a for=url>host</a> is null, or its
- <a>non-relative flag</a> is set, terminate these steps.
+ <a>cannot-be-a-base-URL flag</a> is set, terminate these steps.
 
  <li><p><a>Set the password</a> given <a>context object</a>'s <a for=URL>url</a> and the given
  value.
@@ -2581,8 +2582,8 @@ compatibility with HTML's <code>MessageEvent</code> feature. [[!HTML]]
 <p>The <code><a attribute for=URL>host</a></code> attribute's setter must run these steps:
 
 <ol>
- <li><p>If <a>context object</a>'s <a for=URL>url</a>'s <a>non-relative flag</a> is set, terminate
- these steps.
+ <li><p>If <a>context object</a>'s <a for=URL>url</a>'s <a>cannot-be-a-base-URL flag</a> is set,
+ terminate these steps.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> the given value with <a>context object</a>'s
  <a for=URL>url</a> as <var>url</var> and <a>host state</a> as <var>state override</var>.
@@ -2606,8 +2607,8 @@ does return a <a for=urlsyntax>port</a> so one might have assumed the setter to 
 <p>The <code><a attribute for=URL>hostname</a></code> attribute's setter must run these steps:
 
 <ol>
- <li><p>If <a>context object</a>'s <a for=URL>url</a>'s <a>non-relative flag</a> is set, terminate
- these steps.
+ <li><p>If <a>context object</a>'s <a for=URL>url</a>'s <a>cannot-be-a-base-URL flag</a> is set,
+ terminate these steps.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> the given value with <a>context object</a>'s
  <a for=URL>url</a> as <var>url</var> and <a>hostname state</a> as <var>state override</var>.
@@ -2627,8 +2628,8 @@ does return a <a for=urlsyntax>port</a> so one might have assumed the setter to 
 
 <ol>
  <li><p>If <a>context object</a>'s <a for=URL>url</a>'s <a for=url>host</a> is null, its
- <a>non-relative flag</a> is set, or its <a for=url>scheme</a> is "<code>file</code>", terminate
- these steps.
+ <a>cannot-be-a-base-URL flag</a> is set, or its <a for=url>scheme</a> is "<code>file</code>",
+ terminate these steps.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> the given value with <a>context object</a>'s
  <a for=URL>url</a> as <var>url</var> and <a>port state</a> as <var>state override</var>.
@@ -2637,8 +2638,8 @@ does return a <a for=urlsyntax>port</a> so one might have assumed the setter to 
 <p>The <dfn attribute for=URL><code>pathname</code></dfn> attribute's getter must run these steps:
 
 <ol>
- <li><p>If <a>context object</a>'s <a for=URL>url</a>'s <a>non-relative flag</a> is set, return the
- first string in <a>context object</a>'s <a for=URL>url</a>'s <a for=url>path</a>.
+ <li><p>If <a>context object</a>'s <a for=URL>url</a>'s <a>cannot-be-a-base-URL flag</a> is set,
+ return the first string in <a>context object</a>'s <a for=URL>url</a>'s <a for=url>path</a>.
 
  <li><p>Return "<code>/</code>", followed by the strings in <a>context object</a>'s
  <a for=URL>url</a>'s <a for=url>path</a> (including empty strings), separated from each other by
@@ -2649,8 +2650,8 @@ does return a <a for=urlsyntax>port</a> so one might have assumed the setter to 
 run these steps:
 
 <ol>
- <li><p>If <a>context object</a>'s <a for=URL>url</a>'s <a>non-relative flag</a> is set, terminate
- these steps.
+ <li><p>If <a>context object</a>'s <a for=URL>url</a>'s <a>cannot-be-a-base-URL flag</a> is set,
+ terminate these steps.
 
  <li><p>Empty <a>context object</a>'s <a for=URL>url</a>'s <a for=url>path</a>.
 

--- a/url.html
+++ b/url.html
@@ -11,7 +11,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-url.svg"> </a> </p>
    <h1 class="p-name no-ref allcaps" id="title">URL</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-03-07">7 March 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-03-23">23 March 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Participate:
@@ -666,8 +666,8 @@ null or an <a data-link-type="dfn" href="#ascii-string">ASCII string</a> holding
 either null or a string holding data that can be used for further processing on the
 resource the <a data-link-type="dfn" href="#concept-url">URL</a>’s other components identify. It is initially null. </p>
    <p class="note no-backref" role="note">This is not an <a data-link-type="dfn" href="#ascii-string">ASCII string</a> on purpose. </p>
-   <p>A <a data-link-type="dfn" href="#concept-url">URL</a> also has an associated <dfn data-dfn-type="dfn" data-noexport="" id="non-relative-flag">non-relative flag<a class="self-link" href="#non-relative-flag"></a></dfn>. It is
-initially unset. </p>
+   <p>A <a data-link-type="dfn" href="#concept-url">URL</a> also has an associated <dfn data-dfn-type="dfn" data-noexport="" id="cannot-be-a-base-url-flag"><span id="non-relative-flag">cannot-be-a-base-URL flag</span><a class="self-link" href="#cannot-be-a-base-url-flag"></a></dfn>.
+It is initially unset. </p>
    <p>A <a data-link-type="dfn" href="#concept-url">URL</a> also has an associated <dfn data-dfn-for="url" data-dfn-type="dfn" data-export="" id="concept-url-object">object<a class="self-link" href="#concept-url-object"></a></dfn> that is either null or a <code><a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#blob">Blob</a></code> object. It is initially null. <a data-link-type="biblio" href="#biblio-fileapi">[FILEAPI]</a> </p>
    <p class="note no-backref" role="note">At this point this is used primarily to support
 "<code>blob</code>" <a data-link-type="dfn" href="#concept-url">URLs</a>, but others can be added going forward, hence
@@ -951,15 +951,14 @@ optionally with an <a data-link-type="dfn" href="https://encoding.spec.whatwg.or
           <li>
            <p>Otherwise, if <var>url</var> <a data-link-type="dfn" href="#is-special">is special</a>, <var>base</var> is non-null, and <var>base</var>’s <a data-link-type="dfn" href="#concept-url-scheme">scheme</a> is equal to <var>url</var>’s <a data-link-type="dfn" href="#concept-url-scheme">scheme</a>,
         set <var>state</var> to <a data-link-type="dfn" href="#special-relative-or-authority-state">special relative or authority state</a>. </p>
-           <p class="note no-backref" role="note">This means that <var>base</var>’s <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a> is
-        unset. </p>
+           <p class="note no-backref" role="note">This means that <var>base</var>’s <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a> is unset. </p>
           <li>
            <p>Otherwise, if <var>url</var> <a data-link-type="dfn" href="#is-special">is special</a>, set <var>state</var> to <a data-link-type="dfn" href="#special-authority-slashes-state">special authority slashes state</a>. </p>
           <li>
            <p>Otherwise, if <a data-link-type="dfn" href="#remaining">remaining</a> starts with an "<code>/</code>", set <var>state</var> to <a data-link-type="dfn" href="#path-or-authority-state">path or authority state</a>, and increase <var>pointer</var> by one. </p>
           <li>
-           <p>Otherwise, set <var>url</var>’s <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a>, append an empty
-       string to <var>url</var>’s <a data-link-type="dfn" href="#concept-url-path">path</a>, and set <var>state</var> to <a data-link-type="dfn" href="#non-relative-path-state">non-relative path state</a>. </p>
+           <p>Otherwise, set <var>url</var>’s <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a>, append an empty
+       string to <var>url</var>’s <a data-link-type="dfn" href="#concept-url-path">path</a>, and set <var>state</var> to <a data-link-type="dfn" href="#cannot-be-a-base-url-path-state">cannot-be-a-base-URL path state</a>. </p>
          </ol>
         <li>
          <p>Otherwise, if <var>state override</var> is not given, set <var>buffer</var> to the empty string, <var>state</var> to <a data-link-type="dfn" href="#no-scheme-state">no scheme state</a>, and start over (from the first code point
@@ -971,10 +970,10 @@ optionally with an <a data-link-type="dfn" href="https://encoding.spec.whatwg.or
       <dd>
        <ol>
         <li>
-         <p>If <var>base</var> is null, or <var>base</var>’s <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a> is
+         <p>If <var>base</var> is null, or <var>base</var>’s <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a> is
      set and <a data-link-type="dfn" href="#c">c</a> is not "<code>#</code>", <a data-link-type="dfn" href="#syntax-violation">syntax violation</a>, return failure. </p>
         <li>
-         <p>Otherwise, if <var>base</var>’s <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a> is set and <a data-link-type="dfn" href="#c">c</a> is "<code>#</code>", set <var>url</var>’s <a data-link-type="dfn" href="#concept-url-scheme">scheme</a> to <var>base</var>’s <a data-link-type="dfn" href="#concept-url-scheme">scheme</a>, <var>url</var>’s <a data-link-type="dfn" href="#concept-url-path">path</a> to <var>base</var>’s <a data-link-type="dfn" href="#concept-url-path">path</a>, <var>url</var>’s <a data-link-type="dfn" href="#concept-url-query">query</a> to <var>base</var>’s <a data-link-type="dfn" href="#concept-url-query">query</a>, <var>url</var>’s <a data-link-type="dfn" href="#concept-url-fragment">fragment</a> to the empty string, set <var>url</var>’s <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a>, and set <var>state</var> to <a data-link-type="dfn" href="#fragment-state">fragment state</a>. </p>
+         <p>Otherwise, if <var>base</var>’s <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a> is set and <a data-link-type="dfn" href="#c">c</a> is "<code>#</code>", set <var>url</var>’s <a data-link-type="dfn" href="#concept-url-scheme">scheme</a> to <var>base</var>’s <a data-link-type="dfn" href="#concept-url-scheme">scheme</a>, <var>url</var>’s <a data-link-type="dfn" href="#concept-url-path">path</a> to <var>base</var>’s <a data-link-type="dfn" href="#concept-url-path">path</a>, <var>url</var>’s <a data-link-type="dfn" href="#concept-url-query">query</a> to <var>base</var>’s <a data-link-type="dfn" href="#concept-url-query">query</a>, <var>url</var>’s <a data-link-type="dfn" href="#concept-url-fragment">fragment</a> to the empty string, set <var>url</var>’s <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a>, and set <var>state</var> to <a data-link-type="dfn" href="#fragment-state">fragment state</a>. </p>
         <li>
          <p>Otherwise, if <var>base</var>’s <a data-link-type="dfn" href="#concept-url-scheme">scheme</a> is not
      "<code>file</code>", set <var>state</var> to <a data-link-type="dfn" href="#relative-state">relative state</a> and decrease <var>pointer</var> by one. </p>
@@ -1357,7 +1356,7 @@ optionally with an <a data-link-type="dfn" href="https://encoding.spec.whatwg.or
        and append the result to <var>buffer</var>. </p>
          </ol>
        </ol>
-      <dt><dfn data-dfn-type="dfn" data-noexport="" id="non-relative-path-state">non-relative path state<a class="self-link" href="#non-relative-path-state"></a></dfn> 
+      <dt><dfn data-dfn-type="dfn" data-noexport="" id="cannot-be-a-base-url-path-state">cannot-be-a-base-URL path state<a class="self-link" href="#cannot-be-a-base-url-path-state"></a></dfn> 
       <dd>
        <ol>
         <li>
@@ -1502,7 +1501,7 @@ then runs these steps: </p>
      <p>Otherwise, if <var>url</var>’s <a data-link-type="dfn" href="#concept-url-host">host</a> is null and <var>url</var>’s <a data-link-type="dfn" href="#concept-url-scheme">scheme</a> is "<code>file</code>", append
  "<code>//</code>" to <var>output</var>. </p>
     <li>
-     <p>If <var>url</var>’s <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a> is set, append the first string in <var>url</var>’s <a data-link-type="dfn" href="#concept-url-path">path</a> to <var>output</var>. </p>
+     <p>If <var>url</var>’s <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a> is set, append the first string in <var>url</var>’s <a data-link-type="dfn" href="#concept-url-path">path</a> to <var>output</var>. </p>
     <li>
      <p>Otherwise, append "<code>/</code>", followed by the strings in <var>url</var>’s <a data-link-type="dfn" href="#concept-url-path">path</a> (including empty strings), separated from each other by
  "<code>/</code>", to <var>output</var>. </p>
@@ -1819,7 +1818,7 @@ compatibility with HTML’s <code>MessageEvent</code> feature. <a data-link-type
    <p>The <code><a class="idl-code" data-link-type="attribute" href="#dom-url-username">username</a></code> attribute’s setter must run these steps: </p>
    <ol>
     <li>
-     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#concept-url-host">host</a> is null, or its <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a> is set, terminate these steps. </p>
+     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#concept-url-host">host</a> is null, or its <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a> is set, terminate these steps. </p>
     <li>
      <p><a data-link-type="dfn" href="#set-the-username">Set the username</a> given <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a> and the given
  value. </p>
@@ -1835,7 +1834,7 @@ compatibility with HTML’s <code>MessageEvent</code> feature. <a data-link-type
    <p>The <code><a class="idl-code" data-link-type="attribute" href="#dom-url-password">password</a></code> attribute’s setter must run these steps: </p>
    <ol>
     <li>
-     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#concept-url-host">host</a> is null, or its <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a> is set, terminate these steps. </p>
+     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#concept-url-host">host</a> is null, or its <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a> is set, terminate these steps. </p>
     <li>
      <p><a data-link-type="dfn" href="#set-the-password">Set the password</a> given <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a> and the given
  value. </p>
@@ -1855,8 +1854,8 @@ compatibility with HTML’s <code>MessageEvent</code> feature. <a data-link-type
    <p>The <code><a class="idl-code" data-link-type="attribute" href="#dom-url-host">host</a></code> attribute’s setter must run these steps: </p>
    <ol>
     <li>
-     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a> is set, terminate
- these steps. </p>
+     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a> is set,
+ terminate these steps. </p>
     <li>
      <p><a data-link-type="dfn" href="#concept-basic-url-parser">Basic URL parse</a> the given value with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a> as <var>url</var> and <a data-link-type="dfn" href="#host-state">host state</a> as <var>state override</var>. </p>
    </ol>
@@ -1873,8 +1872,8 @@ does return a <a data-link-type="dfn" href="#syntax-url-port">port</a> so one mi
    <p>The <code><a class="idl-code" data-link-type="attribute" href="#dom-url-hostname">hostname</a></code> attribute’s setter must run these steps: </p>
    <ol>
     <li>
-     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a> is set, terminate
- these steps. </p>
+     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a> is set,
+ terminate these steps. </p>
     <li>
      <p><a data-link-type="dfn" href="#concept-basic-url-parser">Basic URL parse</a> the given value with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a> as <var>url</var> and <a data-link-type="dfn" href="#hostname-state">hostname state</a> as <var>state override</var>. </p>
    </ol>
@@ -1889,16 +1888,16 @@ does return a <a data-link-type="dfn" href="#syntax-url-port">port</a> so one mi
    <p>The <code><a class="idl-code" data-link-type="attribute" href="#dom-url-port">port</a></code> attribute’s setter must run these steps: </p>
    <ol>
     <li>
-     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#concept-url-host">host</a> is null, its <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a> is set, or its <a data-link-type="dfn" href="#concept-url-scheme">scheme</a> is "<code>file</code>", terminate
- these steps. </p>
+     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#concept-url-host">host</a> is null, its <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a> is set, or its <a data-link-type="dfn" href="#concept-url-scheme">scheme</a> is "<code>file</code>",
+ terminate these steps. </p>
     <li>
      <p><a data-link-type="dfn" href="#concept-basic-url-parser">Basic URL parse</a> the given value with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a> as <var>url</var> and <a data-link-type="dfn" href="#port-state">port state</a> as <var>state override</var>. </p>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="URL" data-dfn-type="attribute" data-export="" id="dom-url-pathname"><code>pathname</code><a class="self-link" href="#dom-url-pathname"></a></dfn> attribute’s getter must run these steps: </p>
    <ol>
     <li>
-     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a> is set, return the
- first string in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#concept-url-path">path</a>. </p>
+     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a> is set,
+ return the first string in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#concept-url-path">path</a>. </p>
     <li>
      <p>Return "<code>/</code>", followed by the strings in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#concept-url-path">path</a> (including empty strings), separated from each other by
  "<code>/</code>". </p>
@@ -1907,8 +1906,8 @@ does return a <a data-link-type="dfn" href="#syntax-url-port">port</a> so one mi
 run these steps: </p>
    <ol>
     <li>
-     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#non-relative-flag">non-relative flag</a> is set, terminate
- these steps. </p>
+     <p>If <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a> is set,
+ terminate these steps. </p>
     <li>
      <p>Empty <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#concept-url-path">path</a>. </p>
     <li>
@@ -2152,6 +2151,8 @@ neighboring rights to this work. </p>
    <li><a href="#c">c</a><span>, in §1.1</span>
    <li><a href="#c0-controls">C0 controls</a><span>, in §1</span>
    <li><a href="#c0-controls-and-space">C0 controls and space</a><span>, in §1</span>
+   <li><a href="#cannot-be-a-base-url-flag">cannot-be-a-base-URL flag</a><span>, in §4</span>
+   <li><a href="#cannot-be-a-base-url-path-state">cannot-be-a-base-URL path state</a><span>, in §4.2</span>
    <li><a href="#default-encode-set">default encode set</a><span>, in §1.2</span>
    <li><a href="#default-port">default port</a><span>, in §4</span>
    <li><a href="#dom-urlsearchparams-delete">delete(name)</a><span>, in §6.4</span>
@@ -2228,8 +2229,6 @@ neighboring rights to this work. </p>
    <li><a href="#concept-urlsearchparams-list">list</a><span>, in §6.4</span>
    <li><a href="#local-scheme">local scheme</a><span>, in §4</span>
    <li><a href="#concept-urlsearchparams-new">new</a><span>, in §6.4</span>
-   <li><a href="#non-relative-flag">non-relative flag</a><span>, in §4</span>
-   <li><a href="#non-relative-path-state">non-relative path state</a><span>, in §4.2</span>
    <li><a href="#normalized-windows-drive-letter">normalized Windows drive letter</a><span>, in §1</span>
    <li><a href="#no-scheme-state">no scheme state</a><span>, in §4.2</span>
    <li><a href="#concept-url-object">object</a><span>, in §4</span>


### PR DESCRIPTION
Fix #89.