### PR TITLE
Stop after setting an url’s query to null.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2678,8 +2678,9 @@ steps:
 <ol>
  <li><p>Let <var>url</var> be <a>context object</a>'s <a for=URL>url</a>.
 
- <li><p>If the given value is the empty string, set <var>url</var>'s <a for=url>query</a> to null
- and empty <var>url</var>'s <a for=URL>query object</a>'s <a for=URLSearchParams>list</a>.
+ <li><p>If the given value is the empty string, set <var>url</var>'s <a for=url>query</a> to null,
+ empty <var>url</var>'s <a for=URL>query object</a>'s <a for=URLSearchParams>list</a>,
+ and terminate these steps.
 
  <li><p>Let <var>input</var> be the given value with a single leading "<code>?</code>" removed, if
  any.


### PR DESCRIPTION
Don’t go on to setting it to the empty string in a following step, which makes setting to null pointless

This is probably what was intended, as it is similar to what happens in the `hash` setter.