### PR TITLE
Update origin links now that HTML defines it with for=''.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2093,11 +2093,11 @@ then runs these steps:
 <h3 id=origin>Origin</h3>
 <!-- Still need to watch the final bits -->
 
-<p class=note>See <a spec=html for=origin>origin</a>'s definition in HTML for the necessary
+<p class=note>See <a for=/>origin</a>'s definition in HTML for the necessary
 background information. [[!HTML]]
 
 <p>A <a for=url>URL</a>'s <dfn export for=url id=concept-url-origin>origin</dfn> is the
-<a spec=html for=origin>origin</a> returned by running these steps, switching on
+<a for=/>origin</a> returned by running these steps, switching on
 <a for=url>URL</a>'s <a for=url>scheme</a>:
 
 <dl class=switch>

--- a/url.html
+++ b/url.html
@@ -71,7 +71,7 @@ pre.idl.highlight { color: #708090; }
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-url.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">URL</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-07-28">28 July 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-08-24">24 August 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -2413,7 +2413,7 @@ neighboring rights to this work. </p>
      <li><a href="https://dom.spec.whatwg.org/#context-object">context object</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[file-1]</a> defines the following terms:
+    <a data-link-type="biblio">[FILEAPI]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a>
     </ul>
@@ -2438,8 +2438,6 @@ neighboring rights to this work. </p>
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-encoding">[ENCODING]
    <dd>Anne van Kesteren. <a href="https://encoding.spec.whatwg.org/">Encoding Standard</a>. Living Standard. URL: <a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a>
-   <dt id="biblio-file-1">[FILE-1]
-   <dd>File API URL: <a href="https://w3c.github.io/FileAPI/">https://w3c.github.io/FileAPI/</a>
    <dt id="biblio-fileapi">[FILEAPI]
    <dd>Arun Ranganathan; Jonas Sicking. <a href="https://w3c.github.io/FileAPI/">File API</a>. 21 April 2015. WD. URL: <a href="https://w3c.github.io/FileAPI/">https://w3c.github.io/FileAPI/</a>
    <dt id="biblio-html">[HTML]


### PR DESCRIPTION
I've filed https://github.com/w3c/csswg-drafts/issues/422 about a conflicting definition of "origin".

However, we shouldn't need even as much markup as I'm using (`<a spec=html for=/>origin</a>`), to link to HTML's origin. @tabatkins, adding a `link-defaults` of `spec:html; type:dfn; text:origin; for:/` should cause `<a>origin</a>` to link to HTML, right? It doesn't.