### PR TITLE
Annevk/redo urlsyntax

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -921,7 +921,7 @@ non-null.
 <p>A <a for=/>URL</a> can be designated as <dfn id=concept-base-url>base URL</dfn>.
 
 <p class="note no-backref">A <a>base URL</a> is useful for the <a>URL parser</a> when the
-input might be a <a for=urlsyntax>relative URL</a>.
+input might be a <a>relative-URL string</a>.
 
 <hr>
 
@@ -936,102 +936,93 @@ if any.
 
 <!-- http://tantek.com/2011/238/b1/many-ways-slice-url-name-pieces -->
 
-<p>A <dfn export for=urlsyntax id=syntax-url lt="URL|URL string">URL</dfn> must be either
-a <a>relative URL with fragment</a> or an <a>absolute URL with fragment</a>. To
-disambiguate from a <a for=/>URL record</a> it can also be referred to as a <a>URL string</a>.
+<p>A <dfn export id=syntax-url>URL string</dfn> must be either a
+<a>relative-URL-with-fragment string</a> or an <a>absolute-URL-with-fragment string</a>.
 
 <p>An
-<dfn export for=urlsyntax id=syntax-url-absolute-with-fragment>absolute URL with fragment</dfn>
-must be an <a for=urlsyntax>absolute URL</a>, optionally followed by "<code>#</code>" and a
-<a for=urlsyntax>fragment</a>.
+<dfn export id=syntax-url-absolute-with-fragment>absolute-URL-with-fragment string</dfn> must be an
+<a>absolute-URL string</a>, optionally followed by "<code>#</code>" and a
+<a>URL-fragment string</a>.
 
-<p>An <dfn export for=urlsyntax id=syntax-url-absolute>absolute URL</dfn> must be one of
-the following
+<p>An <dfn export id=syntax-url-absolute>absolute-URL string</dfn> must be one of the following
 
 <ul class=brief>
- <li><p>a <a for=urlsyntax>scheme</a> that is an <a spec=dom>ASCII case-insensitive</a>
- match for a <a>special scheme</a> and not an <a spec=dom>ASCII case-insensitive</a> match
- for "<code>file</code>", followed by "<code>:</code>" and a <a>scheme-relative URL</a>
- <li><p>a <a for=urlsyntax>scheme</a> that is <em>not</em> an
- <a spec=dom>ASCII case-insensitive</a> match for a <a>special scheme</a>, followed by
- "<code>:</code>" and a <a for=urlsyntax>relative URL</a>
- <li><p>a <a for=urlsyntax>scheme</a> that is an <a spec=dom>ASCII case-insensitive</a>
+ <li><p>a <a>URL-scheme string</a> that is an <a spec=dom>ASCII case-insensitive</a> match for a
+ <a>special scheme</a> and not an <a spec=dom>ASCII case-insensitive</a> match for
+ "<code>file</code>", followed by "<code>:</code>" and a <a>scheme-relative-URL string</a>
+ <li><p>a <a>URL-scheme string</a> that is <em>not</em> an <a spec=dom>ASCII case-insensitive</a>
+ match for a <a>special scheme</a>, followed by "<code>:</code>" and a <a>relative-URL string</a>
+ <li><p>a <a>URL-scheme string</a> that is an <a spec=dom>ASCII case-insensitive</a>
  match for "<code>file</code>", followed by "<code>:</code>" and a
- <a>scheme-relative file URL</a>
+ <a>scheme-relative-file-URL string</a>
 </ul>
 
-<p>any optionally followed by "<code>?</code>" and a <a for=urlsyntax>query</a>.
+<p>any optionally followed by "<code>?</code>" and a <a>URL-query string</a>.
 
-<p>A <dfn export for=urlsyntax id=syntax-url-scheme>scheme</dfn> must be one
-<a>ASCII alpha</a>, followed by zero or more of <a>ASCII alphanumeric</a>,
-"<code>+</code>", "<code>-</code>", and "<code>.</code>". <a for=urlsyntax>Schemes</a>
-should be registered in the <cite>IANA URI [sic] Schemes</cite> registry.
+<p>A <dfn export id=syntax-url-scheme>URL-scheme string</dfn> must be one <a>ASCII alpha</a>,
+followed by zero or more of <a>ASCII alphanumeric</a>, "<code>+</code>", "<code>-</code>", and
+"<code>.</code>". <a lt="URL-scheme string">Schemes</a> should be registered in the
+<cite>IANA URI [sic] Schemes</cite> registry.
 [[!IANA-URI-SCHEMES]]
 [[RFC7595]]
 
-<p>A
-<dfn export for=urlsyntax id=syntax-url-relative-with-fragment>relative URL with fragment</dfn>
-must be a <a for=urlsyntax>relative URL</a>, optionally followed by "<code>#</code>" and a
-<a for=urlsyntax>fragment</a>.
+<p>A <dfn export id=syntax-url-relative-with-fragment>relative-URL-with-fragment string</dfn>
+must be a <a>relative-URL string</a>, optionally followed by "<code>#</code>" and a
+<a>URL-fragment string</a>.
 
-<p>A <dfn export for=urlsyntax id=syntax-url-relative>relative URL</dfn> must be one of
-the following, switching on <a>base URL</a>'s <a for=url>scheme</a>:
+<p>A <dfn export id=syntax-url-relative>relative-URL string</dfn> must be one of the following,
+switching on <a>base URL</a>'s <a for=url>scheme</a>:
 
 <dl class=switch>
  <dt>Not "<code>file</code>"
- <dd><p>a <a>scheme-relative URL</a>
- <dd><p>a <a>path-absolute URL</a>
- <dd><p>a <a>path-relative scheme-less URL</a>
+ <dd><p>a <a>scheme-relative-URL string</a>
+ <dd><p>a <a>path-absolute-URL string</a>
+ <dd><p>a <a>path-relative-scheme-less-URL string</a>
  <dt>"<code>file</code>"
- <dd><p>a <a>scheme-relative file URL</a>
- <dd><p>a <a>path-absolute URL</a> if <a>base URL</a>'s <a for=url>host</a> is null
- <dd><p>a <a>path-absolute non-Windows-file URL</a> if <a>base URL</a>'s
- <a for=url>host</a> is non-null
- <dd><p>a <a>path-relative scheme-less URL</a>
+ <dd><p>a <a>scheme-relative-file-URL string</a>
+ <dd><p>a <a>path-absolute-URL string</a> if <a>base URL</a>'s <a for=url>host</a> is null
+ <dd><p>a <a>path-absolute-non-Windows-file-URL string</a> if <a>base URL</a>'s <a for=url>host</a>
+ is non-null
+ <dd><p>a <a>path-relative-scheme-less-URL string</a>
 </dl>
 
-<p>any optionally followed by "<code>?</code>" and a <a for=urlsyntax>query</a>.
+<p>any optionally followed by "<code>?</code>" and a <a>URL-query string</a>.
 
 <p class="note no-backref">A non-null <a>base URL</a> is necessary when
-<a lt="URL parser">parsing</a> a <a for=urlsyntax>relative URL</a>.
+<a lt="URL parser">parsing</a> a <a>relative-URL string</a>.
 
-<p>A <dfn export for=urlsyntax id=syntax-url-scheme-relative>scheme-relative URL</dfn>
-must be "<code>//</code>", followed by a <a for=hostsyntax>host</a>, optionally followed
-by "<code>:</code>" and a <a for=urlsyntax>port</a>, optionally followed by a
-<a>path-absolute URL</a>.
+<p>A <dfn export id=syntax-url-scheme-relative>scheme-relative-URL string</dfn> must be
+"<code>//</code>", followed by a <a for=hostsyntax>host</a>, optionally followed by "<code>:</code>"
+and a <a>URL-port string</a>, optionally followed by a <a>path-absolute-URL string</a>.
 
-<p>A <dfn export for=urlsyntax id=syntax-url-port>port</dfn> must be zero or more
-<a>ASCII digits</a>.
+<p>A <dfn export id=syntax-url-port>URL-port string</dfn> must be zero or more <a>ASCII digits</a>.
 
-<p>A
-<dfn export for=urlsyntax id=syntax-url-file-scheme-relative>scheme-relative file URL</dfn>
-must be "<code>//</code>", followed by one of the following
+<p>A <dfn export id=syntax-url-file-scheme-relative>scheme-relative-file-URL string</dfn> must be
+"<code>//</code>", followed by one of the following
 
 <ul class=brief>
  <li><p>a <a for=hostsyntax>host</a>, optionally followed by a
- <a>path-absolute non-Windows-file URL</a>
- <li><p>a <a>path-absolute URL</a>.
+ <a>path-absolute-non-Windows-file-URL string</a>
+ <li><p>a <a>path-absolute-URL string</a>.
 </ul>
 
-<p>A <dfn export for=urlsyntax id=syntax-url-path-absolute>path-absolute URL</dfn> must be
-"<code>/</code>" followed by a <a>path-relative URL</a>.
+<p>A <dfn export id=syntax-url-path-absolute>path-absolute-URL string</dfn> must be "<code>/</code>"
+followed by a <a>path-relative-URL string</a>.
 
-<p>A
-<dfn export for=urlsyntax id=syntax-url-file-path-absolute>path-absolute non-Windows-file URL</dfn>
-must be a <a>path-absolute URL</a> that does not start with "<code>/</code>", followed by
+<p>A <dfn export id=syntax-url-file-path-absolute>path-absolute-non-Windows-file-URL string</dfn>
+must be a <a>path-absolute-URL string</a> that does not start with "<code>/</code>", followed by
 a <a>Windows drive letter</a>, followed by "<code>/</code>".
 
-<p>A <dfn export for=urlsyntax id=syntax-url-path-relative>path-relative URL</dfn> must be
-zero or more <a for=urlsyntax>path segments</a>, separated from each other by "<code>/</code>", and
-not start with "<code>/</code>".
+<p>A <dfn export id=syntax-url-path-relative>path-relative-URL string</dfn> must be zero or more
+<a lt="URL-path-segment string">path segments</a>, separated from each other by "<code>/</code>",
+and not start with "<code>/</code>".
 
-<p>A
-<dfn export for=urlsyntax id=syntax-url-path-relative-scheme-less>path-relative scheme-less URL</dfn>
-must be a <a>path-relative URL</a> that does not start with a <a for=urlsyntax>scheme</a>
-and "<code>:</code>".
+<p>A <dfn export id=syntax-url-path-relative-scheme-less>path-relative-scheme-less-URL string</dfn>
+must be a <a>path-relative-URL string</a> that does not start with a <a>URL-scheme string</a> and
+"<code>:</code>".
 
-<p>A <dfn export for=urlsyntax id=syntax-url-path-segment>path segment</dfn> must be one
-of the following
+<p>A <dfn export id=syntax-url-path-segment>URL-path-segment string</dfn> must be one of the
+following
 
 <ul class=brief>
  <li><p>zero or more <a>URL units</a>, excluding "<code>/</code>" and "<code>?</code>",
@@ -1041,20 +1032,16 @@ of the following
  <li><p>a <a>double-dot path segment</a>.
 </ul>
 
-<p>A
-<dfn export for=urlsyntax id=syntax-url-path-segment-dot>single-dot path segment</dfn>
-must be "<code>.</code>" or an <a spec=dom>ASCII case-insensitive</a> match for
-"<code>%2e</code>".
+<p>A <dfn export id=syntax-url-path-segment-dot>single-dot path segment</dfn> must be
+"<code>.</code>" or an <a spec=dom>ASCII case-insensitive</a> match for "<code>%2e</code>".
 
-<p>A
-<dfn export for=urlsyntax id=syntax-url-path-segment-dotdot>double-dot path segment</dfn>
-must be "<code>..</code>" or an <a spec=dom>ASCII case-insensitive</a> match for
-"<code>.%2e</code>", "<code>%2e.</code>", or "<code>%2e%2e</code>".
+<p>A <dfn export id=syntax-url-path-segment-dotdot>double-dot path segment</dfn> must be
+"<code>..</code>" or an <a spec=dom>ASCII case-insensitive</a> match for "<code>.%2e</code>",
+"<code>%2e.</code>", or "<code>%2e%2e</code>".
 
-<p>A <dfn export for=urlsyntax id=syntax-url-query>query</dfn> must be zero or more
-<a>URL units</a>.
+<p>A <dfn export id=syntax-url-query>URL-query string</dfn> must be zero or more <a>URL units</a>.
 
-<p>A <dfn export for=urlsyntax id=syntax-url-fragment>fragment</dfn> must be zero or more
+<p>A <dfn export id=syntax-url-fragment>URL-fragment string</dfn> must be zero or more
 <a>URL units</a>.
 
 <p>The <dfn>URL code points</dfn> are <a>ASCII alphanumeric</a>,
@@ -1101,10 +1088,10 @@ U+100000 to U+10FFFD.
 
 <p class=note>Code points higher than U+007F will be converted to
 <a lt="percent-encoded byte">percent-encoded bytes</a> by the <a>URL parser</a>, except for code
-points appearing in <a for=url lt=fragment>fragments</a>.
+points appearing in <a lt="URL-fragment string">fragments</a>.
 
 <p class=note>In HTML, when the document encoding is a legacy encoding, code points in the
-<a for=urlsyntax>query</a> that are higher than U+007F will be converted to
+<a>URL-query string</a> that are higher than U+007F will be converted to
 <a lt="percent-encoded byte">percent-encoded bytes</a> <em>using the document's encoding</em>. This
 can cause problems if a URL that works in one document is copied to another document that uses a
 different document encoding. Using the <a>UTF-8</a> encoding everywhere solves this problem.
@@ -1134,7 +1121,7 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
 
 <p class="note no-backref">There is no conforming way to express a
 <a for=url>username</a> or <a for=url>password</a> of a <a for=/>URL record</a> within a
-<a for=urlsyntax>URL string</a>.
+<a>URL string</a>.
 
 
 <h3 id=url-parsing>URL parsing</h3>
@@ -2172,7 +2159,7 @@ form, with these modifications:
  <li><p>A <a for=/>URL</a>'s <a for=url>host</a> should be rendered using
  <a>domain to Unicode</a>.
 
- <li><p>Other parts of the <a for=urlsyntax>URL</a> should have their sequences of
+ <li><p>Other parts of the <a for=/>URL</a> should have their sequences of
  <a>percent-encoded bytes</a> replaced with code points resulting from
  <a>percent decoding</a> those sequences converted to bytes, unless that renders those
  sequences invisible.
@@ -2482,7 +2469,7 @@ var input = "https://example.org/💩",
     url = new URL(input)
 url.pathname // "/%F0%9F%92%A9"</pre>
 
- <p>This throws an exception if the input is not an <a for=urlsyntax>absolute URL</a>:
+ <p>This throws an exception if the input is not an <a>absolute-URL string</a>:
 
  <pre>
 try {
@@ -2491,7 +2478,7 @@ try {
   // that happened
 }</pre>
 
- <p>A <a>base URL</a> is necessary if the input is a <a for=urlsyntax>relative URL</a>:
+ <p>A <a>base URL</a> is necessary if the input is a <a>relative-URL string</a>:
 
  <pre>
 var input = "/🍣🍺",
@@ -2604,9 +2591,10 @@ compatibility with HTML's <code>MessageEvent</code> feature. [[!HTML]]
 </ol>
 
 <p class="note no-backref">If the given value for the <code><a attribute for=URL>host</a></code>
-attribute's setter lacks a <a for=urlsyntax>port</a>, <a>context object</a>'s <a for=URL>url</a>'s
-<a for=url>port</a> will not change. This can be unexpected as <code>host</code> attribute's getter
-does return a <a for=urlsyntax>port</a> so one might have assumed the setter to always "reset" both.
+attribute's setter lacks a <a lt="URL-port string">port</a>, <a>context object</a>'s
+<a for=URL>url</a>'s <a for=url>port</a> will not change. This can be unexpected as
+<code>host</code> attribute's getter does return a <a>URL-port string</a> so one might have assumed
+the setter to always "reset" both.
 
 <p>The <dfn attribute for=URL><code>hostname</code></dfn> attribute's getter must run these steps:
 

--- a/url.bs
+++ b/url.bs
@@ -230,7 +230,7 @@ an <var>encode set</var>, run these steps:
 taken when rendering, interpreting, and passing <a for=/>URLs</a> around.
 
 <p>When rendering and allocating new <a for=/>URLs</a> "spoofing" needs to be
-considered. An attack whereby one <a for=host>host</a> or <a for=/>URL</a> can be
+considered. An attack whereby one <a for=/>host</a> or <a for=/>URL</a> can be
 confused for another. E.g., consider how 1/l/I, m/rn/rri, 0/O, and а/a can all appear
 eerily similar. Or worse, consider how U+202A and similar code points are invisible.
 [[!UTS36]]
@@ -249,23 +249,23 @@ point <a for=/>URLs</a> from <var>A</var> can come from untrusted sources.
      https://tools.ietf.org/html/rfc3492
      https://mothereff.in/punycode -->
 
-<p>A <dfn export for=host id=concept-host>host</dfn> is a <a for=host>domain</a>, an
-<a for=host>IPv4 address</a>, or an <a for=host>IPv6 address</a>. Typically a
-<a for=host>host</a> serves as a network address, but it is sometimes (ab)used as opaque
+<p>A <dfn export id=concept-host>host</dfn> is a <a>domain</a>, an
+<a>IPv4 address</a>, or an <a>IPv6 address</a>. Typically a
+<a for=/>host</a> serves as a network address, but it is sometimes (ab)used as opaque
 identifier in <a for=/>URLs</a> where a network address is not necessary.
 
 <p class=note>The RFCs referenced in the paragraphs below are for informative purposes only. They
-have no influence on <a for=host>host</a> syntax, parsing, and serialization. Unless stated
+have no influence on <a for=/>host</a> syntax, parsing, and serialization. Unless stated
 otherwise in the sections that follow.
 
-<p>A <dfn export for=host id=concept-domain>domain</dfn> identifies a realm within a
+<p>A <dfn export id=concept-domain>domain</dfn> identifies a realm within a
 network.
 [[RFC1034]]
 
-<p>An <dfn export for=host id=concept-ipv4>IPv4 address</dfn> is a 32-bit identifier.
+<p>An <dfn export id=concept-ipv4>IPv4 address</dfn> is a 32-bit identifier.
 [[RFC791]]
 
-<p>An <dfn export for=host id=concept-ipv6>IPv6 address</dfn> is a 128-bit identifier and
+<p>An <dfn export id=concept-ipv6>IPv6 address</dfn> is a 128-bit identifier and
 for the purposes of this specification represented as an ordered list of
 eight <dfn id=concept-ipv6-piece lt='IPv6 piece'>16-bit pieces</dfn>.
 [[RFC4291]]
@@ -277,7 +277,7 @@ eight <dfn id=concept-ipv6-piece lt='IPv6 piece'>16-bit pieces</dfn>.
 <h3 id=idna>IDNA</h3>
 
 <p>The <dfn id=concept-domain-to-ascii>domain to ASCII</dfn> given a
-<a for=host>domain</a> <var>domain</var>, runs these steps:
+<a>domain</a> <var>domain</var>, runs these steps:
 
 <ol>
  <li><p>Let <var>result</var> be the result of running
@@ -292,7 +292,7 @@ eight <dfn id=concept-ipv6-piece lt='IPv6 piece'>16-bit pieces</dfn>.
 </ol>
 
 <p>The <dfn id=concept-domain-to-unicode>domain to Unicode</dfn> given a
-<a for=host>domain</a> <var>domain</var>, runs these steps:
+<a>domain</a> <var>domain</var>, runs these steps:
 
 <ol>
  <li><p>Let <var>result</var> be the result of running
@@ -307,9 +307,9 @@ eight <dfn id=concept-ipv6-piece lt='IPv6 piece'>16-bit pieces</dfn>.
 
 <h3 id=host-syntax>Host syntax</h3>
 
-<p>A <dfn export for=hostsyntax id=syntax-host>host</dfn> must be a
-<a for=hostsyntax>domain</a>, an <a for=hostsyntax>IPv4 address</a>, or "<code>[</code>",
-followed by an <a for=hostsyntax>IPv6 address</a>, followed by "<code>]</code>".
+<p>A <dfn export id=syntax-host>host string</dfn> must be a <a>domain string</a>, an
+<a>IPv4 address string</a>, or "<code>[</code>", followed by an <a>IPv6 address string</a>, followed
+by "<code>]</code>".
 
 <p>A <var>domain</var> is a <dfn>valid domain</dfn> if these steps return success:
 
@@ -336,14 +336,14 @@ followed by an <a for=hostsyntax>IPv6 address</a>, followed by "<code>]</code>".
 <a>valid domain</a> rather than through a whack-a-mole:
 <a href=https://www.w3.org/Bugs/Public/show_bug.cgi?id=25334>bug 25334</a>.
 
-<p>A <dfn export for=hostsyntax id=syntax-host-domain>domain</dfn> must be a string that
-is a <a>valid domain</a>.
+<p>A <dfn export id=syntax-host-domain>domain string</dfn> must be a string that is a
+<a>valid domain</a>.
 
-<p>An <dfn export for=hostsyntax id=syntax-host-ipv4>IPv4 address</dfn> must be four
-sequences of up to three <a>ASCII digits</a> per sequence, each representing a decimal
-number no greater than 255, and separated from each other by "<code>.</code>".
+<p>An <dfn export id=syntax-host-ipv4>IPv4 address string</dfn> must be four sequences of up to
+three <a>ASCII digits</a> per sequence, each representing a decimal number no greater than 255, and
+separated from each other by "<code>.</code>".
 
-<p>An <dfn export for=hostsyntax id=syntax-host-ipv6>IPv6 address</dfn> is defined in the
+<p>An <dfn export id=syntax-host-ipv6>IPv6 address string</dfn> is defined in the
 <a href="https://tools.ietf.org/html/rfc4291#section-2.2">"Text Representation of Addresses" chapter of IP Version 6 Addressing Architecture</a>.
 [[!RFC4291]]
 <!-- https://tools.ietf.org/html/rfc5952 updates that RFC, but it seems as
@@ -406,7 +406,7 @@ steps:
  <li><p>Let <var>ipv4Host</var> be the result of <a lt="IPv4 parser">IPv4 parsing</a>
  <var>asciiDomain</var>.
 
- <li><p>If <var>ipv4Host</var> is an <a for=host>IPv4 address</a> or failure, return
+ <li><p>If <var>ipv4Host</var> is an <a>IPv4 address</a> or failure, return
  <var>ipv4Host</var>.
 
  <li><p>Return <var>asciiDomain</var> if the <var>Unicode flag</var> is unset, and the
@@ -481,7 +481,7 @@ runs these steps:
     <p>If <var>part</var> is the empty string, return <var>input</var>.
 
     <p class="example no-backref" id=example-c2afe535><code>0..0x300</code> is a
-    <a for=host>domain</a>, not an <a for=host>IPv4 address</a>.
+    <a>domain</a>, not an <a>IPv4 address</a>.
 
    <li><p>Let <var>n</var> be the result of <a lt="IPv4 number parser">parsing</a>
    <var>part</var> using <var>syntaxViolationFlag</var>.
@@ -525,7 +525,7 @@ runs these steps:
 then runs these steps:
 
 <ol>
- <li><p>Let <var>address</var> be a new <a for=host>IPv6 address</a> with its
+ <li><p>Let <var>address</var> be a new <a>IPv6 address</a> with its
  <a lt='IPv6 piece'>16-bit pieces</a> initialized to 0.
 
  <li><p>Let <var>piece pointer</var> be a pointer into
@@ -705,22 +705,22 @@ They serve no purpose other than being a location the algorithm can jump to.
 <h3 id=host-serializing>Host serializing</h3>
 
 <p>The <dfn id=concept-host-serializer lt="host serializer">host serializer</dfn> takes a
-<a for=host>host</a> <var>host</var> and then runs these steps:
+<a for=/>host</a> <var>host</var> and then runs these steps:
 
 <ol>
- <li><p>If <var>host</var> is an <a for=host>IPv4 address</a>, return the result of
+ <li><p>If <var>host</var> is an <a>IPv4 address</a>, return the result of
  running the <a>IPv4 serializer</a> on <var>host</var>.
 
- <li><p>Otherwise, if <var>host</var> is an <a for=host>IPv6 address</a>, return
+ <li><p>Otherwise, if <var>host</var> is an <a>IPv6 address</a>, return
  "<code>[</code>", followed by the result of running the
  <a>IPv6 serializer</a> on <var>host</var>,
  followed by "<code>]</code>".
 
- <li><p>Otherwise, <var>host</var> is a <a for=host>domain</a>, return <var>host</var>.
+ <li><p>Otherwise, <var>host</var> is a <a>domain</a>, return <var>host</var>.
 </ol>
 
 The <dfn id=concept-ipv4-serializer>IPv4 serializer</dfn> takes an
-<a for=host>IPv4 address</a> <var>address</var> and then runs these steps:
+<a>IPv4 address</a> <var>address</var> and then runs these steps:
 
 <ol>
  <li><p>Let <var>output</var> be the empty string.
@@ -743,7 +743,7 @@ The <dfn id=concept-ipv4-serializer>IPv4 serializer</dfn> takes an
 </ol>
 
 <p>The <dfn id=concept-ipv6-serializer>IPv6 serializer</dfn> takes an
-<a for=host>IPv6 address</a> <var>address</var> and then runs these steps:
+<a>IPv6 address</a> <var>address</var> and then runs these steps:
 
 <ol>
  <li><p>Let <var>output</var> be the empty string.
@@ -797,7 +797,7 @@ A Recommendation for IPv6 Address Text Representation.
 
 <h3 id=host-equivalence>Host equivalence</h3>
 
-To determine whether a <a for=host>host</a> <var>A</var>
+To determine whether a <a for=/>host</a> <var>A</var>
 <dfn export for=host id=concept-host-equals>equals</dfn> <var>B</var>, return true if
 <var>A</var> is <var>B</var>, and false otherwise.
 
@@ -830,7 +830,7 @@ either null or an <a>ASCII string</a> identifying a user's credentials. It is in
 null.
 
 <p>A  <a for=/>URL</a>'s <dfn export for=url id=concept-url-host>host</dfn> is either
-null or a <a for=host>host</a>. It is initially null.
+null or a <a for=/>host</a>. It is initially null.
 
 <p>A  <a for=/>URL</a>'s <dfn export for=url id=concept-url-port>port</dfn> is either
 null or a 16-bit unsigned integer that identifies a networking port. It is initially null.
@@ -992,7 +992,7 @@ switching on <a>base URL</a>'s <a for=url>scheme</a>:
 <a lt="URL parser">parsing</a> a <a>relative-URL string</a>.
 
 <p>A <dfn export id=syntax-url-scheme-relative>scheme-relative-URL string</dfn> must be
-"<code>//</code>", followed by a <a for=hostsyntax>host</a>, optionally followed by "<code>:</code>"
+"<code>//</code>", followed by a <a>host string</a>, optionally followed by "<code>:</code>"
 and a <a>URL-port string</a>, optionally followed by a <a>path-absolute-URL string</a>.
 
 <p>A <dfn export id=syntax-url-port>URL-port string</dfn> must be zero or more <a>ASCII digits</a>.
@@ -1001,7 +1001,7 @@ and a <a>URL-port string</a>, optionally followed by a <a>path-absolute-URL stri
 "<code>//</code>", followed by one of the following
 
 <ul class=brief>
- <li><p>a <a for=hostsyntax>host</a>, optionally followed by a
+ <li><p>a <a>host string</a>, optionally followed by a
  <a>path-absolute-non-Windows-file-URL string</a>
  <li><p>a <a>path-absolute-URL string</a>.
 </ul>
@@ -1014,8 +1014,8 @@ must be a <a>path-absolute-URL string</a> that does not start with "<code>/</cod
 a <a>Windows drive letter</a>, followed by "<code>/</code>".
 
 <p>A <dfn export id=syntax-url-path-relative>path-relative-URL string</dfn> must be zero or more
-<a lt="URL-path-segment string">path segments</a>, separated from each other by "<code>/</code>",
-and not start with "<code>/</code>".
+<a>URL-path-segment strings</a>, separated from each other by "<code>/</code>", and not start with
+"<code>/</code>".
 
 <p>A <dfn export id=syntax-url-path-relative-scheme-less>path-relative-scheme-less-URL string</dfn>
 must be a <a>path-relative-URL string</a> that does not start with a <a>URL-scheme string</a> and

--- a/url.html
+++ b/url.html
@@ -781,73 +781,72 @@ its <a data-link-type="dfn" href="#concept-url-username">username</a> is not the
 non-null. </p>
    <p>A <a data-link-type="dfn" href="#concept-url">URL</a> can be designated as <dfn data-dfn-type="dfn" data-noexport="" id="concept-base-url">base URL<a class="self-link" href="#concept-base-url"></a></dfn>. </p>
    <p class="note no-backref" role="note">A <a data-link-type="dfn" href="#concept-base-url">base URL</a> is useful for the <a data-link-type="dfn" href="#concept-url-parser">URL parser</a> when the
-input might be a <a data-link-type="dfn" href="#syntax-url-relative">relative URL</a>. </p>
+input might be a <a data-link-type="dfn" href="#syntax-url-relative">relative-URL string</a>. </p>
    <hr>
    <p id="pop-a-urls-path">To <dfn data-dfn-type="dfn" data-local-lt="shorten" data-noexport="" id="shorten-a-urls-path">shorten a <var>url</var>’s path<a class="self-link" href="#shorten-a-urls-path"></a></dfn>, if <var>url</var>’s <a data-link-type="dfn" href="#concept-url-scheme">scheme</a> is not "<code>file</code>" or <var>url</var>’s <a data-link-type="dfn" href="#concept-url-path">path</a> does not contain a single string that is a <a data-link-type="dfn" href="#normalized-windows-drive-letter">normalized Windows drive letter</a>, remove <var>url</var>’s <a data-link-type="dfn" href="#concept-url-path">path</a>’s last string,
 if any. </p>
    <h3 class="heading settled" data-level="4.1" id="url-syntax"><span class="secno">4.1. </span><span class="content">URL syntax</span><a class="self-link" href="#url-syntax"></a></h3>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" data-lt="URL|URL string" id="syntax-url">URL<a class="self-link" href="#syntax-url"></a></dfn> must be either
-a <a data-link-type="dfn" href="#syntax-url-relative-with-fragment">relative URL with fragment</a> or an <a data-link-type="dfn" href="#syntax-url-absolute-with-fragment">absolute URL with fragment</a>. To
-disambiguate from a <a data-link-type="dfn" href="#concept-url">URL record</a> it can also be referred to as a <a data-link-type="dfn" href="#syntax-url">URL string</a>. </p>
-   <p>An <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-absolute-with-fragment">absolute URL with fragment<a class="self-link" href="#syntax-url-absolute-with-fragment"></a></dfn> must be an <a data-link-type="dfn" href="#syntax-url-absolute">absolute URL</a>, optionally followed by "<code>#</code>" and a <a data-link-type="dfn" href="#syntax-url-fragment">fragment</a>. </p>
-   <p>An <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-absolute">absolute URL<a class="self-link" href="#syntax-url-absolute"></a></dfn> must be one of
-the following </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url">URL string<a class="self-link" href="#syntax-url"></a></dfn> must be either a <a data-link-type="dfn" href="#syntax-url-relative-with-fragment">relative-URL-with-fragment string</a> or an <a data-link-type="dfn" href="#syntax-url-absolute-with-fragment">absolute-URL-with-fragment string</a>. </p>
+   <p>An <dfn data-dfn-type="dfn" data-export="" id="syntax-url-absolute-with-fragment">absolute-URL-with-fragment string<a class="self-link" href="#syntax-url-absolute-with-fragment"></a></dfn> must be an <a data-link-type="dfn" href="#syntax-url-absolute">absolute-URL string</a>, optionally followed by "<code>#</code>" and a <a data-link-type="dfn" href="#syntax-url-fragment">URL-fragment string</a>. </p>
+   <p>An <dfn data-dfn-type="dfn" data-export="" id="syntax-url-absolute">absolute-URL string<a class="self-link" href="#syntax-url-absolute"></a></dfn> must be one of the following </p>
    <ul class="brief">
     <li>
-     <p>a <a data-link-type="dfn" href="#syntax-url-scheme">scheme</a> that is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for a <a data-link-type="dfn" href="#special-scheme">special scheme</a> and not an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match
- for "<code>file</code>", followed by "<code>:</code>" and a <a data-link-type="dfn" href="#syntax-url-scheme-relative">scheme-relative URL</a> </p>
+     <p>a <a data-link-type="dfn" href="#syntax-url-scheme">URL-scheme string</a> that is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for a <a data-link-type="dfn" href="#special-scheme">special scheme</a> and not an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for
+ "<code>file</code>", followed by "<code>:</code>" and a <a data-link-type="dfn" href="#syntax-url-scheme-relative">scheme-relative-URL string</a> </p>
     <li>
-     <p>a <a data-link-type="dfn" href="#syntax-url-scheme">scheme</a> that is <em>not</em> an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for a <a data-link-type="dfn" href="#special-scheme">special scheme</a>, followed by
- "<code>:</code>" and a <a data-link-type="dfn" href="#syntax-url-relative">relative URL</a> </p>
+     <p>a <a data-link-type="dfn" href="#syntax-url-scheme">URL-scheme string</a> that is <em>not</em> an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for a <a data-link-type="dfn" href="#special-scheme">special scheme</a>, followed by "<code>:</code>" and a <a data-link-type="dfn" href="#syntax-url-relative">relative-URL string</a> </p>
     <li>
-     <p>a <a data-link-type="dfn" href="#syntax-url-scheme">scheme</a> that is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for "<code>file</code>", followed by "<code>:</code>" and a <a data-link-type="dfn" href="#syntax-url-file-scheme-relative">scheme-relative file URL</a> </p>
+     <p>a <a data-link-type="dfn" href="#syntax-url-scheme">URL-scheme string</a> that is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for "<code>file</code>", followed by "<code>:</code>" and a <a data-link-type="dfn" href="#syntax-url-file-scheme-relative">scheme-relative-file-URL string</a> </p>
    </ul>
-   <p>any optionally followed by "<code>?</code>" and a <a data-link-type="dfn" href="#syntax-url-query">query</a>. </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-scheme">scheme<a class="self-link" href="#syntax-url-scheme"></a></dfn> must be one <a data-link-type="dfn" href="#ascii-alpha">ASCII alpha</a>, followed by zero or more of <a data-link-type="dfn" href="#ascii-alphanumeric">ASCII alphanumeric</a>,
-"<code>+</code>", "<code>-</code>", and "<code>.</code>". <a data-link-type="dfn" href="#syntax-url-scheme">Schemes</a> should be registered in the <cite>IANA URI [sic] Schemes</cite> registry. <a data-link-type="biblio" href="#biblio-iana-uri-schemes">[IANA-URI-SCHEMES]</a> <a data-link-type="biblio" href="#biblio-rfc7595">[RFC7595]</a> </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-relative-with-fragment">relative URL with fragment<a class="self-link" href="#syntax-url-relative-with-fragment"></a></dfn> must be a <a data-link-type="dfn" href="#syntax-url-relative">relative URL</a>, optionally followed by "<code>#</code>" and a <a data-link-type="dfn" href="#syntax-url-fragment">fragment</a>. </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-relative">relative URL<a class="self-link" href="#syntax-url-relative"></a></dfn> must be one of
-the following, switching on <a data-link-type="dfn" href="#concept-base-url">base URL</a>’s <a data-link-type="dfn" href="#concept-url-scheme">scheme</a>: </p>
+   <p>any optionally followed by "<code>?</code>" and a <a data-link-type="dfn" href="#syntax-url-query">URL-query string</a>. </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-scheme">URL-scheme string<a class="self-link" href="#syntax-url-scheme"></a></dfn> must be one <a data-link-type="dfn" href="#ascii-alpha">ASCII alpha</a>,
+followed by zero or more of <a data-link-type="dfn" href="#ascii-alphanumeric">ASCII alphanumeric</a>, "<code>+</code>", "<code>-</code>", and
+"<code>.</code>". <a data-link-type="dfn" href="#syntax-url-scheme">Schemes</a> should be registered in the <cite>IANA URI [sic] Schemes</cite> registry. <a data-link-type="biblio" href="#biblio-iana-uri-schemes">[IANA-URI-SCHEMES]</a> <a data-link-type="biblio" href="#biblio-rfc7595">[RFC7595]</a> </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-relative-with-fragment">relative-URL-with-fragment string<a class="self-link" href="#syntax-url-relative-with-fragment"></a></dfn> must be a <a data-link-type="dfn" href="#syntax-url-relative">relative-URL string</a>, optionally followed by "<code>#</code>" and a <a data-link-type="dfn" href="#syntax-url-fragment">URL-fragment string</a>. </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-relative">relative-URL string<a class="self-link" href="#syntax-url-relative"></a></dfn> must be one of the following,
+switching on <a data-link-type="dfn" href="#concept-base-url">base URL</a>’s <a data-link-type="dfn" href="#concept-url-scheme">scheme</a>: </p>
    <dl class="switch">
     <dt>Not "<code>file</code>" 
     <dd>
-     <p>a <a data-link-type="dfn" href="#syntax-url-scheme-relative">scheme-relative URL</a> </p>
+     <p>a <a data-link-type="dfn" href="#syntax-url-scheme-relative">scheme-relative-URL string</a> </p>
     <dd>
-     <p>a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute URL</a> </p>
+     <p>a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute-URL string</a> </p>
     <dd>
-     <p>a <a data-link-type="dfn" href="#syntax-url-path-relative-scheme-less">path-relative scheme-less URL</a> </p>
+     <p>a <a data-link-type="dfn" href="#syntax-url-path-relative-scheme-less">path-relative-scheme-less-URL string</a> </p>
     <dt>"<code>file</code>" 
     <dd>
-     <p>a <a data-link-type="dfn" href="#syntax-url-file-scheme-relative">scheme-relative file URL</a> </p>
+     <p>a <a data-link-type="dfn" href="#syntax-url-file-scheme-relative">scheme-relative-file-URL string</a> </p>
     <dd>
-     <p>a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute URL</a> if <a data-link-type="dfn" href="#concept-base-url">base URL</a>’s <a data-link-type="dfn" href="#concept-url-host">host</a> is null </p>
+     <p>a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute-URL string</a> if <a data-link-type="dfn" href="#concept-base-url">base URL</a>’s <a data-link-type="dfn" href="#concept-url-host">host</a> is null </p>
     <dd>
-     <p>a <a data-link-type="dfn" href="#syntax-url-file-path-absolute">path-absolute non-Windows-file URL</a> if <a data-link-type="dfn" href="#concept-base-url">base URL</a>’s <a data-link-type="dfn" href="#concept-url-host">host</a> is non-null </p>
+     <p>a <a data-link-type="dfn" href="#syntax-url-file-path-absolute">path-absolute-non-Windows-file-URL string</a> if <a data-link-type="dfn" href="#concept-base-url">base URL</a>’s <a data-link-type="dfn" href="#concept-url-host">host</a> is non-null </p>
     <dd>
-     <p>a <a data-link-type="dfn" href="#syntax-url-path-relative-scheme-less">path-relative scheme-less URL</a> </p>
+     <p>a <a data-link-type="dfn" href="#syntax-url-path-relative-scheme-less">path-relative-scheme-less-URL string</a> </p>
    </dl>
-   <p>any optionally followed by "<code>?</code>" and a <a data-link-type="dfn" href="#syntax-url-query">query</a>. </p>
-   <p class="note no-backref" role="note">A non-null <a data-link-type="dfn" href="#concept-base-url">base URL</a> is necessary when <a data-link-type="dfn" href="#concept-url-parser">parsing</a> a <a data-link-type="dfn" href="#syntax-url-relative">relative URL</a>. </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-scheme-relative">scheme-relative URL<a class="self-link" href="#syntax-url-scheme-relative"></a></dfn> must be "<code>//</code>", followed by a <a data-link-type="dfn" href="#syntax-host">host</a>, optionally followed
-by "<code>:</code>" and a <a data-link-type="dfn" href="#syntax-url-port">port</a>, optionally followed by a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute URL</a>. </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-port">port<a class="self-link" href="#syntax-url-port"></a></dfn> must be zero or more <a data-link-type="dfn" href="#ascii-digits">ASCII digits</a>. </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-file-scheme-relative">scheme-relative file URL<a class="self-link" href="#syntax-url-file-scheme-relative"></a></dfn> must be "<code>//</code>", followed by one of the following </p>
+   <p>any optionally followed by "<code>?</code>" and a <a data-link-type="dfn" href="#syntax-url-query">URL-query string</a>. </p>
+   <p class="note no-backref" role="note">A non-null <a data-link-type="dfn" href="#concept-base-url">base URL</a> is necessary when <a data-link-type="dfn" href="#concept-url-parser">parsing</a> a <a data-link-type="dfn" href="#syntax-url-relative">relative-URL string</a>. </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-scheme-relative">scheme-relative-URL string<a class="self-link" href="#syntax-url-scheme-relative"></a></dfn> must be
+"<code>//</code>", followed by a <a data-link-type="dfn" href="#syntax-host">host</a>, optionally followed by "<code>:</code>"
+and a <a data-link-type="dfn" href="#syntax-url-port">URL-port string</a>, optionally followed by a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute-URL string</a>. </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-port">URL-port string<a class="self-link" href="#syntax-url-port"></a></dfn> must be zero or more <a data-link-type="dfn" href="#ascii-digits">ASCII digits</a>. </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-file-scheme-relative">scheme-relative-file-URL string<a class="self-link" href="#syntax-url-file-scheme-relative"></a></dfn> must be
+"<code>//</code>", followed by one of the following </p>
    <ul class="brief">
     <li>
-     <p>a <a data-link-type="dfn" href="#syntax-host">host</a>, optionally followed by a <a data-link-type="dfn" href="#syntax-url-file-path-absolute">path-absolute non-Windows-file URL</a> </p>
+     <p>a <a data-link-type="dfn" href="#syntax-host">host</a>, optionally followed by a <a data-link-type="dfn" href="#syntax-url-file-path-absolute">path-absolute-non-Windows-file-URL string</a> </p>
     <li>
-     <p>a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute URL</a>. </p>
+     <p>a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute-URL string</a>. </p>
    </ul>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-path-absolute">path-absolute URL<a class="self-link" href="#syntax-url-path-absolute"></a></dfn> must be
-"<code>/</code>" followed by a <a data-link-type="dfn" href="#syntax-url-path-relative">path-relative URL</a>. </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-file-path-absolute">path-absolute non-Windows-file URL<a class="self-link" href="#syntax-url-file-path-absolute"></a></dfn> must be a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute URL</a> that does not start with "<code>/</code>", followed by
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-path-absolute">path-absolute-URL string<a class="self-link" href="#syntax-url-path-absolute"></a></dfn> must be "<code>/</code>"
+followed by a <a data-link-type="dfn" href="#syntax-url-path-relative">path-relative-URL string</a>. </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-file-path-absolute">path-absolute-non-Windows-file-URL string<a class="self-link" href="#syntax-url-file-path-absolute"></a></dfn> must be a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute-URL string</a> that does not start with "<code>/</code>", followed by
 a <a data-link-type="dfn" href="#windows-drive-letter">Windows drive letter</a>, followed by "<code>/</code>". </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-path-relative">path-relative URL<a class="self-link" href="#syntax-url-path-relative"></a></dfn> must be
-zero or more <a data-link-type="dfn" href="#syntax-url-path-segment">path segments</a>, separated from each other by "<code>/</code>", and
-not start with "<code>/</code>". </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-path-relative-scheme-less">path-relative scheme-less URL<a class="self-link" href="#syntax-url-path-relative-scheme-less"></a></dfn> must be a <a data-link-type="dfn" href="#syntax-url-path-relative">path-relative URL</a> that does not start with a <a data-link-type="dfn" href="#syntax-url-scheme">scheme</a> and "<code>:</code>". </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-path-segment">path segment<a class="self-link" href="#syntax-url-path-segment"></a></dfn> must be one
-of the following </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-path-relative">path-relative-URL string<a class="self-link" href="#syntax-url-path-relative"></a></dfn> must be zero or more <a data-link-type="dfn" href="#syntax-url-path-segment">path segments</a>, separated from each other by "<code>/</code>",
+and not start with "<code>/</code>". </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-path-relative-scheme-less">path-relative-scheme-less-URL string<a class="self-link" href="#syntax-url-path-relative-scheme-less"></a></dfn> must be a <a data-link-type="dfn" href="#syntax-url-path-relative">path-relative-URL string</a> that does not start with a <a data-link-type="dfn" href="#syntax-url-scheme">URL-scheme string</a> and
+"<code>:</code>". </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-path-segment">URL-path-segment string<a class="self-link" href="#syntax-url-path-segment"></a></dfn> must be one of the
+following </p>
    <ul class="brief">
     <li>
      <p>zero or more <a data-link-type="dfn" href="#url-units">URL units</a>, excluding "<code>/</code>" and "<code>?</code>",
@@ -857,12 +856,13 @@ of the following </p>
     <li>
      <p>a <a data-link-type="dfn" href="#syntax-url-path-segment-dotdot">double-dot path segment</a>. </p>
    </ul>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-path-segment-dot">single-dot path segment<a class="self-link" href="#syntax-url-path-segment-dot"></a></dfn> must be "<code>.</code>" or an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for
-"<code>%2e</code>". </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-path-segment-dotdot">double-dot path segment<a class="self-link" href="#syntax-url-path-segment-dotdot"></a></dfn> must be "<code>..</code>" or an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for
-"<code>.%2e</code>", "<code>%2e.</code>", or "<code>%2e%2e</code>". </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-query">query<a class="self-link" href="#syntax-url-query"></a></dfn> must be zero or more <a data-link-type="dfn" href="#url-units">URL units</a>. </p>
-   <p>A <dfn data-dfn-for="urlsyntax" data-dfn-type="dfn" data-export="" id="syntax-url-fragment">fragment<a class="self-link" href="#syntax-url-fragment"></a></dfn> must be zero or more <a data-link-type="dfn" href="#url-units">URL units</a>. </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-path-segment-dot">single-dot path segment<a class="self-link" href="#syntax-url-path-segment-dot"></a></dfn> must be
+"<code>.</code>" or an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for "<code>%2e</code>". </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-path-segment-dotdot">double-dot path segment<a class="self-link" href="#syntax-url-path-segment-dotdot"></a></dfn> must be
+"<code>..</code>" or an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for "<code>.%2e</code>",
+"<code>%2e.</code>", or "<code>%2e%2e</code>". </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-query">URL-query string<a class="self-link" href="#syntax-url-query"></a></dfn> must be zero or more <a data-link-type="dfn" href="#url-units">URL units</a>. </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-fragment">URL-fragment string<a class="self-link" href="#syntax-url-fragment"></a></dfn> must be zero or more <a data-link-type="dfn" href="#url-units">URL units</a>. </p>
    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="url-code-points">URL code points<a class="self-link" href="#url-code-points"></a></dfn> are <a data-link-type="dfn" href="#ascii-alphanumeric">ASCII alphanumeric</a>,
 "<code>!</code>",
 "<code>$</code>",
@@ -905,8 +905,8 @@ U+E0000 to U+EFFFD,
 U+F0000 to U+FFFFD,
 U+100000 to U+10FFFD. </p>
    <p class="note" role="note">Code points higher than U+007F will be converted to <a data-link-type="dfn" href="#percent-encoded-byte">percent-encoded bytes</a> by the <a data-link-type="dfn" href="#concept-url-parser">URL parser</a>, except for code
-points appearing in <a data-link-type="dfn" href="#concept-url-fragment">fragments</a>. </p>
-   <p class="note" role="note">In HTML, when the document encoding is a legacy encoding, code points in the <a data-link-type="dfn" href="#syntax-url-query">query</a> that are higher than U+007F will be converted to <a data-link-type="dfn" href="#percent-encoded-byte">percent-encoded bytes</a> <em>using the document’s encoding</em>. This
+points appearing in <a data-link-type="dfn" href="#syntax-url-fragment">fragments</a>. </p>
+   <p class="note" role="note">In HTML, when the document encoding is a legacy encoding, code points in the <a data-link-type="dfn" href="#syntax-url-query">URL-query string</a> that are higher than U+007F will be converted to <a data-link-type="dfn" href="#percent-encoded-byte">percent-encoded bytes</a> <em>using the document’s encoding</em>. This
 can cause problems if a URL that works in one document is copied to another document that uses a
 different document encoding. Using the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8">UTF-8</a> encoding everywhere solves this problem. </p>
    <div class="example" id="query-encoding-example">
@@ -1642,7 +1642,7 @@ background information. <a data-link-type="biblio" href="#biblio-html">[HTML]</a
     <li>
      <p>A <a data-link-type="dfn" href="#concept-url">URL</a>’s <a data-link-type="dfn" href="#concept-url-host">host</a> should be rendered using <a data-link-type="dfn" href="#concept-domain-to-unicode">domain to Unicode</a>. </p>
     <li>
-     <p>Other parts of the <a data-link-type="dfn" href="#syntax-url">URL</a> should have their sequences of <a data-link-type="dfn" href="#percent-encoded-byte">percent-encoded bytes</a> replaced with code points resulting from <a data-link-type="dfn" href="#percent-decode">percent decoding</a> those sequences converted to bytes, unless that renders those
+     <p>Other parts of the <a data-link-type="dfn" href="#concept-url">URL</a> should have their sequences of <a data-link-type="dfn" href="#percent-encoded-byte">percent-encoded bytes</a> replaced with code points resulting from <a data-link-type="dfn" href="#percent-decode">percent decoding</a> those sequences converted to bytes, unless that renders those
  sequences invisible. </p>
    </ul>
    <p>For the purposes of bidirectional text it should be rendered as if it were in a
@@ -1834,13 +1834,13 @@ when invoked, must run these steps: </p>
 <pre>var input = "https://example.org/💩",
     url = new URL(input)
 url.pathname // "/%F0%9F%92%A9"</pre>
-    <p>This throws an exception if the input is not an <a data-link-type="dfn" href="#syntax-url-absolute">absolute URL</a>: </p>
+    <p>This throws an exception if the input is not an <a data-link-type="dfn" href="#syntax-url-absolute">absolute-URL string</a>: </p>
 <pre>try {
   var url = new URL("/🍣🍺")
 } catch(e) {
   // that happened
 }</pre>
-    <p>A <a data-link-type="dfn" href="#concept-base-url">base URL</a> is necessary if the input is a <a data-link-type="dfn" href="#syntax-url-relative">relative URL</a>: </p>
+    <p>A <a data-link-type="dfn" href="#concept-base-url">base URL</a> is necessary if the input is a <a data-link-type="dfn" href="#syntax-url-relative">relative-URL string</a>: </p>
 <pre>var input = "/🍣🍺",
     url = new URL(input, document.baseURI)
 url.href // "https://url.spec.whatwg.org/%F0%9F%8D%A3%F0%9F%8D%BA"</pre>
@@ -1916,8 +1916,8 @@ compatibility with HTML’s <code>MessageEvent</code> feature. <a data-link-type
     <li>
      <p><a data-link-type="dfn" href="#concept-basic-url-parser">Basic URL parse</a> the given value with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a> as <var>url</var> and <a data-link-type="dfn" href="#host-state">host state</a> as <var>state override</var>. </p>
    </ol>
-   <p class="note no-backref" role="note">If the given value for the <code><a class="idl-code" data-link-type="attribute" href="#dom-url-host">host</a></code> attribute’s setter lacks a <a data-link-type="dfn" href="#syntax-url-port">port</a>, <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#concept-url-port">port</a> will not change. This can be unexpected as <code>host</code> attribute’s getter
-does return a <a data-link-type="dfn" href="#syntax-url-port">port</a> so one might have assumed the setter to always "reset" both. </p>
+   <p class="note no-backref" role="note">If the given value for the <code><a class="idl-code" data-link-type="attribute" href="#dom-url-host">host</a></code> attribute’s setter lacks a <a data-link-type="dfn" href="#syntax-url-port">port</a>, <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-url-url">url</a>’s <a data-link-type="dfn" href="#concept-url-port">port</a> will not change. This can be unexpected as <code>host</code> attribute’s getter does return a <a data-link-type="dfn" href="#syntax-url-port">URL-port string</a> so one might have assumed
+the setter to always "reset" both. </p>
    <p>The <dfn class="idl-code" data-dfn-for="URL" data-dfn-type="attribute" data-export="" id="dom-url-hostname"><code>hostname</code><a class="self-link" href="#dom-url-hostname"></a></dfn> attribute’s getter must run these steps: </p>
    <ol>
     <li>
@@ -2200,8 +2200,8 @@ neighboring rights to this work. </p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#syntax-url-absolute">absolute URL</a><span>, in §4.1</span>
-   <li><a href="#syntax-url-absolute-with-fragment">absolute URL with fragment</a><span>, in §4.1</span>
+   <li><a href="#syntax-url-absolute">absolute-URL string</a><span>, in §4.1</span>
+   <li><a href="#syntax-url-absolute-with-fragment">absolute-URL-with-fragment string</a><span>, in §4.1</span>
    <li><a href="#dom-urlsearchparams-append">append(name, value)</a><span>, in §6.3</span>
    <li><a href="#concept-urlencoded">application/x-www-form-urlencoded</a><span>, in §5</span>
    <li><a href="#ascii-alpha">ASCII alpha</a><span>, in §1</span>
@@ -2241,12 +2241,7 @@ neighboring rights to this work. </p>
    <li><a href="#file-host-state">file host state</a><span>, in §4.2</span>
    <li><a href="#file-slash-state">file slash state</a><span>, in §4.2</span>
    <li><a href="#file-state">file state</a><span>, in §4.2</span>
-   <li>
-    fragment
-    <ul>
-     <li><a href="#concept-url-fragment">dfn for url</a><span>, in §4</span>
-     <li><a href="#syntax-url-fragment">dfn for urlsyntax</a><span>, in §4.1</span>
-    </ul>
+   <li><a href="#concept-url-fragment">fragment</a><span>, in §4</span>
    <li><a href="#fragment-state">fragment state</a><span>, in §4.2</span>
    <li><a href="#dom-urlsearchparams-getall">getAll(name)</a><span>, in §6.3</span>
    <li><a href="#dom-urlsearchparams-get">get(name)</a><span>, in §6.3</span>
@@ -2311,13 +2306,12 @@ neighboring rights to this work. </p>
      <li><a href="#dom-url-password">attribute for URL</a><span>, in §6.2</span>
     </ul>
    <li><a href="#concept-url-path">path</a><span>, in §4</span>
-   <li><a href="#syntax-url-file-path-absolute">path-absolute non-Windows-file URL</a><span>, in §4.1</span>
-   <li><a href="#syntax-url-path-absolute">path-absolute URL</a><span>, in §4.1</span>
+   <li><a href="#syntax-url-file-path-absolute">path-absolute-non-Windows-file-URL string</a><span>, in §4.1</span>
+   <li><a href="#syntax-url-path-absolute">path-absolute-URL string</a><span>, in §4.1</span>
    <li><a href="#dom-url-pathname">pathname</a><span>, in §6.2</span>
    <li><a href="#path-or-authority-state">path or authority state</a><span>, in §4.2</span>
-   <li><a href="#syntax-url-path-relative-scheme-less">path-relative scheme-less URL</a><span>, in §4.1</span>
-   <li><a href="#syntax-url-path-relative">path-relative URL</a><span>, in §4.1</span>
-   <li><a href="#syntax-url-path-segment">path segment</a><span>, in §4.1</span>
+   <li><a href="#syntax-url-path-relative-scheme-less">path-relative-scheme-less-URL string</a><span>, in §4.1</span>
+   <li><a href="#syntax-url-path-relative">path-relative-URL string</a><span>, in §4.1</span>
    <li><a href="#path-start-state">path start state</a><span>, in §4.2</span>
    <li><a href="#path-state">path state</a><span>, in §4.2</span>
    <li><a href="#percent-decode">percent decode</a><span>, in §1.2</span>
@@ -2327,32 +2321,21 @@ neighboring rights to this work. </p>
     port
     <ul>
      <li><a href="#concept-url-port">dfn for url</a><span>, in §4</span>
-     <li><a href="#syntax-url-port">dfn for urlsyntax</a><span>, in §4.1</span>
      <li><a href="#dom-url-port">attribute for URL</a><span>, in §6.2</span>
     </ul>
    <li><a href="#port-state">port state</a><span>, in §4.2</span>
    <li><a href="#dom-url-protocol">protocol</a><span>, in §6.2</span>
-   <li>
-    query
-    <ul>
-     <li><a href="#concept-url-query">dfn for url</a><span>, in §4</span>
-     <li><a href="#syntax-url-query">dfn for urlsyntax</a><span>, in §4.1</span>
-    </ul>
+   <li><a href="#concept-url-query">query</a><span>, in §4</span>
    <li><a href="#concept-url-query-object">query object</a><span>, in §6</span>
    <li><a href="#query-state">query state</a><span>, in §4.2</span>
    <li><a href="#relative-slash-state">relative slash state</a><span>, in §4.2</span>
    <li><a href="#relative-state">relative state</a><span>, in §4.2</span>
-   <li><a href="#syntax-url-relative">relative URL</a><span>, in §4.1</span>
-   <li><a href="#syntax-url-relative-with-fragment">relative URL with fragment</a><span>, in §4.1</span>
+   <li><a href="#syntax-url-relative">relative-URL string</a><span>, in §4.1</span>
+   <li><a href="#syntax-url-relative-with-fragment">relative-URL-with-fragment string</a><span>, in §4.1</span>
    <li><a href="#remaining">remaining</a><span>, in §1.1</span>
-   <li>
-    scheme
-    <ul>
-     <li><a href="#concept-url-scheme">dfn for url</a><span>, in §4</span>
-     <li><a href="#syntax-url-scheme">dfn for urlsyntax</a><span>, in §4.1</span>
-    </ul>
-   <li><a href="#syntax-url-file-scheme-relative">scheme-relative file URL</a><span>, in §4.1</span>
-   <li><a href="#syntax-url-scheme-relative">scheme-relative URL</a><span>, in §4.1</span>
+   <li><a href="#concept-url-scheme">scheme</a><span>, in §4</span>
+   <li><a href="#syntax-url-file-scheme-relative">scheme-relative-file-URL string</a><span>, in §4.1</span>
+   <li><a href="#syntax-url-scheme-relative">scheme-relative-URL string</a><span>, in §4.1</span>
    <li><a href="#scheme-start-state">scheme start state</a><span>, in §4.2</span>
    <li><a href="#scheme-state">scheme state</a><span>, in §4.2</span>
    <li><a href="#dom-url-search">search</a><span>, in §6.2</span>
@@ -2382,7 +2365,6 @@ neighboring rights to this work. </p>
     URL
     <ul>
      <li><a href="#concept-url">definition of</a><span>, in §4</span>
-     <li><a href="#syntax-url">dfn for urlsyntax</a><span>, in §4.1</span>
      <li><a href="#url">(interface)</a><span>, in §6</span>
     </ul>
    <li><a href="#concept-url-url">url</a><span>, in §6</span>
@@ -2391,9 +2373,14 @@ neighboring rights to this work. </p>
    <li><a href="#concept-urlencoded-parser">urlencoded parser</a><span>, in §5.1</span>
    <li><a href="#concept-urlencoded-serializer">urlencoded serializer</a><span>, in §5.2</span>
    <li><a href="#concept-urlencoded-string-parser">urlencoded string parser</a><span>, in §5.3</span>
+   <li><a href="#syntax-url-fragment">URL-fragment string</a><span>, in §4.1</span>
    <li><a href="#concept-urlsearchparams-url-object">url object</a><span>, in §6.3</span>
    <li><a href="#concept-url-parser">URL parser</a><span>, in §4.2</span>
+   <li><a href="#syntax-url-path-segment">URL-path-segment string</a><span>, in §4.1</span>
+   <li><a href="#syntax-url-port">URL-port string</a><span>, in §4.1</span>
+   <li><a href="#syntax-url-query">URL-query string</a><span>, in §4.1</span>
    <li><a href="#concept-url">URL record</a><span>, in §4</span>
+   <li><a href="#syntax-url-scheme">URL-scheme string</a><span>, in §4.1</span>
    <li><a href="#urlsearchparams">URLSearchParams</a><span>, in §6.3</span>
    <li><a href="#dom-urlsearchparams-urlsearchparams">URLSearchParams(init)</a><span>, in §6.3</span>
    <li><a href="#concept-url-serializer">URL serializer</a><span>, in §4.3</span>

--- a/url.html
+++ b/url.html
@@ -300,15 +300,15 @@ want to leak. <var>B</var> might receive input it did not expect and take an act
 harms the user. In particular, <var>B</var> should never trust <var>A</var>, as at some
 point <a data-link-type="dfn" href="#concept-url">URLs</a> from <var>A</var> can come from untrusted sources. </p>
    <h2 class="heading settled" data-level="3" id="hosts-(domains-and-ip-addresses)"><span class="secno">3. </span><span class="content">Hosts (domains and IP addresses)</span><a class="self-link" href="#hosts-%28domains-and-ip-addresses%29"></a></h2>
-   <p>A <dfn data-dfn-for="host" data-dfn-type="dfn" data-export="" id="concept-host">host<a class="self-link" href="#concept-host"></a></dfn> is a <a data-link-type="dfn" href="#concept-domain">domain</a>, an <a data-link-type="dfn" href="#concept-ipv4">IPv4 address</a>, or an <a data-link-type="dfn" href="#concept-ipv6">IPv6 address</a>. Typically a <a data-link-type="dfn" href="#concept-host">host</a> serves as a network address, but it is sometimes (ab)used as opaque
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="concept-host">host<a class="self-link" href="#concept-host"></a></dfn> is a <a data-link-type="dfn" href="#concept-domain">domain</a>, an <a data-link-type="dfn" href="#concept-ipv4">IPv4 address</a>, or an <a data-link-type="dfn" href="#concept-ipv6">IPv6 address</a>. Typically a <a data-link-type="dfn" href="#concept-host">host</a> serves as a network address, but it is sometimes (ab)used as opaque
 identifier in <a data-link-type="dfn" href="#concept-url">URLs</a> where a network address is not necessary. </p>
    <p class="note" role="note">The RFCs referenced in the paragraphs below are for informative purposes only. They
 have no influence on <a data-link-type="dfn" href="#concept-host">host</a> syntax, parsing, and serialization. Unless stated
 otherwise in the sections that follow. </p>
-   <p>A <dfn data-dfn-for="host" data-dfn-type="dfn" data-export="" id="concept-domain">domain<a class="self-link" href="#concept-domain"></a></dfn> identifies a realm within a
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="concept-domain">domain<a class="self-link" href="#concept-domain"></a></dfn> identifies a realm within a
 network. <a data-link-type="biblio" href="#biblio-rfc1034">[RFC1034]</a> </p>
-   <p>An <dfn data-dfn-for="host" data-dfn-type="dfn" data-export="" id="concept-ipv4">IPv4 address<a class="self-link" href="#concept-ipv4"></a></dfn> is a 32-bit identifier. <a data-link-type="biblio" href="#biblio-rfc791">[RFC791]</a> </p>
-   <p>An <dfn data-dfn-for="host" data-dfn-type="dfn" data-export="" id="concept-ipv6">IPv6 address<a class="self-link" href="#concept-ipv6"></a></dfn> is a 128-bit identifier and
+   <p>An <dfn data-dfn-type="dfn" data-export="" id="concept-ipv4">IPv4 address<a class="self-link" href="#concept-ipv4"></a></dfn> is a 32-bit identifier. <a data-link-type="biblio" href="#biblio-rfc791">[RFC791]</a> </p>
+   <p>An <dfn data-dfn-type="dfn" data-export="" id="concept-ipv6">IPv6 address<a class="self-link" href="#concept-ipv6"></a></dfn> is a 128-bit identifier and
 for the purposes of this specification represented as an ordered list of
 eight <dfn data-dfn-type="dfn" data-lt="IPv6 piece" data-noexport="" id="concept-ipv6-piece">16-bit pieces<a class="self-link" href="#concept-ipv6-piece"></a></dfn>. <a data-link-type="biblio" href="#biblio-rfc4291">[RFC4291]</a> </p>
    <p class="note" role="note">Support for <code>&lt;zone_id></code> is <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=27234#c2">intentionally omitted</a>. </p>
@@ -330,8 +330,8 @@ eight <dfn data-dfn-type="dfn" data-lt="IPv6 piece" data-noexport="" id="concept
      <p>Signify <a data-link-type="dfn" href="#syntax-violation">syntax violations</a> for any returned errors, and then, return <var>result</var>. </p>
    </ol>
    <h3 class="heading settled" data-level="3.2" id="host-syntax"><span class="secno">3.2. </span><span class="content">Host syntax</span><a class="self-link" href="#host-syntax"></a></h3>
-   <p>A <dfn data-dfn-for="hostsyntax" data-dfn-type="dfn" data-export="" id="syntax-host">host<a class="self-link" href="#syntax-host"></a></dfn> must be a <a data-link-type="dfn" href="#syntax-host-domain">domain</a>, an <a data-link-type="dfn" href="#syntax-host-ipv4">IPv4 address</a>, or "<code>[</code>",
-followed by an <a data-link-type="dfn" href="#syntax-host-ipv6">IPv6 address</a>, followed by "<code>]</code>". </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-host">host string<a class="self-link" href="#syntax-host"></a></dfn> must be a <a data-link-type="dfn" href="#syntax-host-domain">domain string</a>, an <a data-link-type="dfn" href="#syntax-host-ipv4">IPv4 address string</a>, or "<code>[</code>", followed by an <a data-link-type="dfn" href="#syntax-host-ipv6">IPv6 address string</a>, followed
+by "<code>]</code>". </p>
    <p>A <var>domain</var> is a <dfn data-dfn-type="dfn" data-noexport="" id="valid-domain">valid domain<a class="self-link" href="#valid-domain"></a></dfn> if these steps return success: </p>
    <ol>
     <li>
@@ -346,12 +346,11 @@ followed by an <a data-link-type="dfn" href="#syntax-host-ipv6">IPv6 address</a>
      <p>Return success. </p>
    </ol>
    <p class="XXX">Ideally we define this in terms of a sequence of code points that make up a <a data-link-type="dfn" href="#valid-domain">valid domain</a> rather than through a whack-a-mole: <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=25334">bug 25334</a>. </p>
-   <p>A <dfn data-dfn-for="hostsyntax" data-dfn-type="dfn" data-export="" id="syntax-host-domain">domain<a class="self-link" href="#syntax-host-domain"></a></dfn> must be a string that
-is a <a data-link-type="dfn" href="#valid-domain">valid domain</a>. </p>
-   <p>An <dfn data-dfn-for="hostsyntax" data-dfn-type="dfn" data-export="" id="syntax-host-ipv4">IPv4 address<a class="self-link" href="#syntax-host-ipv4"></a></dfn> must be four
-sequences of up to three <a data-link-type="dfn" href="#ascii-digits">ASCII digits</a> per sequence, each representing a decimal
-number no greater than 255, and separated from each other by "<code>.</code>". </p>
-   <p>An <dfn data-dfn-for="hostsyntax" data-dfn-type="dfn" data-export="" id="syntax-host-ipv6">IPv6 address<a class="self-link" href="#syntax-host-ipv6"></a></dfn> is defined in the <a href="https://tools.ietf.org/html/rfc4291#section-2.2">"Text Representation of Addresses" chapter of IP Version 6 Addressing Architecture</a>. <a data-link-type="biblio" href="#biblio-rfc4291">[RFC4291]</a> </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-host-domain">domain string<a class="self-link" href="#syntax-host-domain"></a></dfn> must be a string that is a <a data-link-type="dfn" href="#valid-domain">valid domain</a>. </p>
+   <p>An <dfn data-dfn-type="dfn" data-export="" id="syntax-host-ipv4">IPv4 address string<a class="self-link" href="#syntax-host-ipv4"></a></dfn> must be four sequences of up to
+three <a data-link-type="dfn" href="#ascii-digits">ASCII digits</a> per sequence, each representing a decimal number no greater than 255, and
+separated from each other by "<code>.</code>". </p>
+   <p>An <dfn data-dfn-type="dfn" data-export="" id="syntax-host-ipv6">IPv6 address string<a class="self-link" href="#syntax-host-ipv6"></a></dfn> is defined in the <a href="https://tools.ietf.org/html/rfc4291#section-2.2">"Text Representation of Addresses" chapter of IP Version 6 Addressing Architecture</a>. <a data-link-type="biblio" href="#biblio-rfc4291">[RFC4291]</a> </p>
    <h3 class="heading settled" data-level="3.3" id="host-parsing"><span class="secno">3.3. </span><span class="content">Host parsing</span><a class="self-link" href="#host-parsing"></a></h3>
    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="concept-host-parser">host parser<a class="self-link" href="#concept-host-parser"></a></dfn> takes a string <var>input</var> and
 an optional <var>Unicode flag</var> (unset unless stated otherwise), and then runs these
@@ -826,14 +825,14 @@ switching on <a data-link-type="dfn" href="#concept-base-url">base URL</a>’s <
    <p>any optionally followed by "<code>?</code>" and a <a data-link-type="dfn" href="#syntax-url-query">URL-query string</a>. </p>
    <p class="note no-backref" role="note">A non-null <a data-link-type="dfn" href="#concept-base-url">base URL</a> is necessary when <a data-link-type="dfn" href="#concept-url-parser">parsing</a> a <a data-link-type="dfn" href="#syntax-url-relative">relative-URL string</a>. </p>
    <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-scheme-relative">scheme-relative-URL string<a class="self-link" href="#syntax-url-scheme-relative"></a></dfn> must be
-"<code>//</code>", followed by a <a data-link-type="dfn" href="#syntax-host">host</a>, optionally followed by "<code>:</code>"
+"<code>//</code>", followed by a <a data-link-type="dfn" href="#syntax-host">host string</a>, optionally followed by "<code>:</code>"
 and a <a data-link-type="dfn" href="#syntax-url-port">URL-port string</a>, optionally followed by a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute-URL string</a>. </p>
    <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-port">URL-port string<a class="self-link" href="#syntax-url-port"></a></dfn> must be zero or more <a data-link-type="dfn" href="#ascii-digits">ASCII digits</a>. </p>
    <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-file-scheme-relative">scheme-relative-file-URL string<a class="self-link" href="#syntax-url-file-scheme-relative"></a></dfn> must be
 "<code>//</code>", followed by one of the following </p>
    <ul class="brief">
     <li>
-     <p>a <a data-link-type="dfn" href="#syntax-host">host</a>, optionally followed by a <a data-link-type="dfn" href="#syntax-url-file-path-absolute">path-absolute-non-Windows-file-URL string</a> </p>
+     <p>a <a data-link-type="dfn" href="#syntax-host">host string</a>, optionally followed by a <a data-link-type="dfn" href="#syntax-url-file-path-absolute">path-absolute-non-Windows-file-URL string</a> </p>
     <li>
      <p>a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute-URL string</a>. </p>
    </ul>
@@ -841,8 +840,8 @@ and a <a data-link-type="dfn" href="#syntax-url-port">URL-port string</a>, optio
 followed by a <a data-link-type="dfn" href="#syntax-url-path-relative">path-relative-URL string</a>. </p>
    <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-file-path-absolute">path-absolute-non-Windows-file-URL string<a class="self-link" href="#syntax-url-file-path-absolute"></a></dfn> must be a <a data-link-type="dfn" href="#syntax-url-path-absolute">path-absolute-URL string</a> that does not start with "<code>/</code>", followed by
 a <a data-link-type="dfn" href="#windows-drive-letter">Windows drive letter</a>, followed by "<code>/</code>". </p>
-   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-path-relative">path-relative-URL string<a class="self-link" href="#syntax-url-path-relative"></a></dfn> must be zero or more <a data-link-type="dfn" href="#syntax-url-path-segment">path segments</a>, separated from each other by "<code>/</code>",
-and not start with "<code>/</code>". </p>
+   <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-path-relative">path-relative-URL string<a class="self-link" href="#syntax-url-path-relative"></a></dfn> must be zero or more <a data-link-type="dfn" href="#syntax-url-path-segment">URL-path-segment strings</a>, separated from each other by "<code>/</code>", and not start with
+"<code>/</code>". </p>
    <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-path-relative-scheme-less">path-relative-scheme-less-URL string<a class="self-link" href="#syntax-url-path-relative-scheme-less"></a></dfn> must be a <a data-link-type="dfn" href="#syntax-url-path-relative">path-relative-URL string</a> that does not start with a <a data-link-type="dfn" href="#syntax-url-scheme">URL-scheme string</a> and
 "<code>:</code>". </p>
    <p>A <dfn data-dfn-type="dfn" data-export="" id="syntax-url-path-segment">URL-path-segment string<a class="self-link" href="#syntax-url-path-segment"></a></dfn> must be one of the
@@ -2221,12 +2220,8 @@ neighboring rights to this work. </p>
    <li><a href="#default-encode-set">default encode set</a><span>, in §1.2</span>
    <li><a href="#default-port">default port</a><span>, in §4</span>
    <li><a href="#dom-urlsearchparams-delete">delete(name)</a><span>, in §6.3</span>
-   <li>
-    domain
-    <ul>
-     <li><a href="#concept-domain">dfn for host</a><span>, in §3</span>
-     <li><a href="#syntax-host-domain">dfn for hostsyntax</a><span>, in §3.2</span>
-    </ul>
+   <li><a href="#concept-domain">domain</a><span>, in §3</span>
+   <li><a href="#syntax-host-domain">domain string</a><span>, in §3.2</span>
    <li><a href="#concept-domain-to-ascii">domain to ASCII</a><span>, in §3.1</span>
    <li><a href="#concept-domain-to-unicode">domain to Unicode</a><span>, in §3.1</span>
    <li><a href="#syntax-url-path-segment-dotdot">double-dot path segment</a><span>, in §4.1</span>
@@ -2250,8 +2245,7 @@ neighboring rights to this work. </p>
    <li>
     host
     <ul>
-     <li><a href="#concept-host">dfn for host</a><span>, in §3</span>
-     <li><a href="#syntax-host">dfn for hostsyntax</a><span>, in §3.2</span>
+     <li><a href="#concept-host">definition of</a><span>, in §3</span>
      <li><a href="#concept-url-host">dfn for url</a><span>, in §4</span>
      <li><a href="#dom-url-host">attribute for URL</a><span>, in §6.2</span>
     </ul>
@@ -2260,24 +2254,17 @@ neighboring rights to this work. </p>
    <li><a href="#concept-host-parser">host parser</a><span>, in §3.3</span>
    <li><a href="#concept-host-serializer">host serializer</a><span>, in §3.4</span>
    <li><a href="#host-state">host state</a><span>, in §4.2</span>
+   <li><a href="#syntax-host">host string</a><span>, in §3.2</span>
    <li><a href="#dom-url-href">href</a><span>, in §6.2</span>
    <li><a href="#http-scheme">HTTP(S) scheme</a><span>, in §4</span>
    <li><a href="#include-credentials">include credentials</a><span>, in §4</span>
-   <li>
-    IPv4 address
-    <ul>
-     <li><a href="#concept-ipv4">dfn for host</a><span>, in §3</span>
-     <li><a href="#syntax-host-ipv4">dfn for hostsyntax</a><span>, in §3.2</span>
-    </ul>
+   <li><a href="#concept-ipv4">IPv4 address</a><span>, in §3</span>
+   <li><a href="#syntax-host-ipv4">IPv4 address string</a><span>, in §3.2</span>
    <li><a href="#ipv4-number-parser">IPv4 number parser</a><span>, in §3.3</span>
    <li><a href="#concept-ipv4-parser">IPv4 parser</a><span>, in §3.3</span>
    <li><a href="#concept-ipv4-serializer">IPv4 serializer</a><span>, in §3.4</span>
-   <li>
-    IPv6 address
-    <ul>
-     <li><a href="#concept-ipv6">dfn for host</a><span>, in §3</span>
-     <li><a href="#syntax-host-ipv6">dfn for hostsyntax</a><span>, in §3.2</span>
-    </ul>
+   <li><a href="#concept-ipv6">IPv6 address</a><span>, in §3</span>
+   <li><a href="#syntax-host-ipv6">IPv6 address string</a><span>, in §3.2</span>
    <li><a href="#concept-ipv6-parser">IPv6 parser</a><span>, in §3.3</span>
    <li><a href="#concept-ipv6-parser-finale">IPv6 parser Finale</a><span>, in §3.3</span>
    <li><a href="#concept-ipv6-parser-ipv4">IPv6 parser IPv4</a><span>, in §3.3</span>


### PR DESCRIPTION
Don’t introduce “host record”, “domain record” etc. for now since “host
string”, “domain string” seem clear enough as distinguishers.