### PR TITLE
Return failure in state override scheme parsing

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1263,7 +1263,11 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
      <var>state</var> to <a>no scheme state</a>, and decrease
      <var>pointer</var> by one.
 
-     <li><p>Otherwise, <a>syntax violation</a>, terminate this algorithm.
+     <li>
+      <p>Otherwise, <a>syntax violation</a>, return failure.
+
+      <p class=note>This indication of failure is used exclusively by {{Location}} object's
+      {{Location/protocol}} attribute.
     </ol>
 
    <dt><dfn>scheme state</dfn>
@@ -1330,7 +1334,12 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
      <a>no scheme state</a>, and start over (from the first code point
      in <var>input</var>).
 
-     <li><p>Otherwise, <a>syntax violation</a>, terminate this algorithm.
+     <li>
+      <p>Otherwise, <a>syntax violation</a>, return failure.
+
+      <p class=note>This indication of failure is used exclusively by {{Location}} object's
+      {{Location/protocol}} attribute. Furthermore, the non-failure termination earlier in this
+      state is an intentional difference for defining that attribute.
     </ol>
 
    <dt><dfn>no scheme state</dfn>


### PR DESCRIPTION
This is necessary to define the behavior of the Location object’s
protocol attribute, which throws on syntax errors rather than silently
ignoring them as other protocol setters do.

Tests: https://github.com/w3c/web-platform-tests/pull/4412.

This is the cleanup work mentioned in
https://github.com/whatwg/html/commit/f0a73659b4046cc35a28855f3544dead66345689
that is happening way late.