### PR TITLE
Only support UTF-8 for the urlencoded parser

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2210,7 +2210,7 @@ distinguish between the two. E.g., users are expected to make trust decisions ba
 <h2 id="application/x-www-form-urlencoded"><code>application/x-www-form-urlencoded</code></h2>
 
 <p>The <dfn export id=concept-urlencoded><code>application/x-www-form-urlencoded</code></dfn> format
-provides a simple way to encode name-value pairs.
+provides a way to encode name-value pairs.
 
 <p class="note no-backref">The <code>application/x-www-form-urlencoded</code> format is in many ways
 an aberrant monstrosity, the result of many years of implementation accidents and compromises

--- a/url.bs
+++ b/url.bs
@@ -2210,8 +2210,7 @@ distinguish between the two. E.g., users are expected to make trust decisions ba
 <h2 id="application/x-www-form-urlencoded"><code>application/x-www-form-urlencoded</code></h2>
 
 <p>The <dfn export id=concept-urlencoded><code>application/x-www-form-urlencoded</code></dfn> format
-is a simple way to encode name-value pairs in a byte sequence where all bytes are
-<a>ASCII bytes</a>.
+provides a simple way to encode name-value pairs.
 
 <p class="note no-backref">The <code>application/x-www-form-urlencoded</code> format is in many ways
 an aberrant monstrosity, the result of many years of implementation accidents and compromises
@@ -2233,12 +2232,6 @@ conforming.
 takes a byte sequence <var>input</var>, and then runs these steps:
 
 <ol>
- <li>
-  <p>If <var>input</var> contains bytes that are not <a>ASCII bytes</a>, then return failure.
-
-  <p class="note no-backref">This can only happen if <var>input</var> was not generated through the
-  <a lt='urlencoded serializer'>serializer</a> or {{URLSearchParams}}.
-
  <li><p>Let <var>sequences</var> be the result of splitting <var>input</var> on
  `<code>&amp;</code>`.
  <!-- XXX define splitting? DOM does not do it -->

--- a/url.bs
+++ b/url.bs
@@ -2223,27 +2223,18 @@ sequences. Unfortunately the format is in widespread use due to the prevalence o
 
 <h3 id=urlencoded-parsing><code>application/x-www-form-urlencoded</code> parsing</h3>
 
-<p class="note no-backref">The features provided by the
-<a lt="urlencoded parser"><code>application/x-www-form-urlencoded</code> parser</a> are mainly
-relevant for server-oriented implementations. A browser-based implementation only needs what the
-<a lt="urlencoded string parser"><code>application/x-www-form-urlencoded</code> string parser</a>
-requires.
+<p class="note no-backref">A legacy server-oriented implementation might have to support
+<a for=/>encodings</a> other than <a>UTF-8</a> as well as have special logic for tuples of which the
+name is `<code>_charset</code>`. Such logic is not described here as only <a>UTF-8</a> is
+conforming.
 
 <p>The
 <dfn export id=concept-urlencoded-parser lt='urlencoded parser'><code>application/x-www-form-urlencoded</code> parser</dfn>
-takes a byte sequence <var>input</var>, optionally with an <a for=/>encoding</a>
-<var>encoding override</var>, and optionally with a <i>use _charset_ flag</i>, and then runs these
-steps:
+takes a byte sequence <var>input</var>, and then runs these steps:
 
 <ol>
- <li><p>Let <var>encoding</var> be <a>UTF-8</a>.
-
- <li><p>If <var>encoding override</var> is given, set <var>encoding</var> to
- <var>encoding override</var>.
-
  <li>
-  <p>If <var>encoding</var> is not <a>UTF-8</a> and <var>input</var> contains bytes that are not
-  <a>ASCII bytes</a>, return failure.
+  <p>If <var>input</var> contains bytes that are not <a>ASCII bytes</a>, then return failure.
 
   <p class="note no-backref">This can only happen if <var>input</var> was not generated through the
   <a lt='urlencoded serializer'>serializer</a> or {{URLSearchParams}}.
@@ -2277,18 +2268,6 @@ steps:
    <li><p>Replace any `<code>+</code>` in <var>name</var> and
    <var>value</var> with 0x20.
 
-   <li>
-    <p>If <i>use _charset_ flag</i> is set and <var>name</var> is `<code>_charset_</code>`, run
-    these substeps:
-
-    <ol>
-     <li><p>Let <var>result</var> be the result of <a>getting an encoding</a> for <var>value</var>,
-     <a lt="UTF-8 decode without BOM">decoded</a>.
-
-     <li><p>If <var>result</var> is not failure, unset <i>use _charset_ flag</i> and set
-     <var>encoding</var> to <var>result</var>.
-    </ol>
-
    <li><p>Add a tuple consisting of <var>name</var> and <var>value</var> to <var>tuples</var>.
   </ol>
 
@@ -2297,8 +2276,8 @@ steps:
 
  <li><p>For each name-value tuple in <var>tuples</var>, append a name-value tuple to
  <var>output</var> where the new name and value appended to <var>output</var> are the result of
- running <a>decode</a> on the <a lt="percent decode">percent decoding</a> of the name and value from
- <var>tuples</var>, respectively, using <var>encoding</var>.
+ running <a>UTF-8 decode without BOM</a> on the <a lt="percent decode">percent decoding</a> of the
+ name and value from <var>tuples</var>, respectively, using <var>encoding</var>.
 
  <li><p>Return <var>output</var>.
 </ol>


### PR DESCRIPTION
Fixes #84.