### PR TITLE
Make URLSearchParams' record constructor more flexible

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2756,7 +2756,7 @@ steps:
 <h3 id=interface-urlsearchparams>Interface {{URLSearchParams}}</h3>
 
 <pre class=idl>
-[Constructor(optional (sequence&lt;sequence&lt;USVString>> or record&lt;USVString, USVString> or USVString) init = ""),
+[Constructor(optional (sequence&lt;sequence&lt;USVString>> or record&lt;USVString, (USVString or sequence&lt;USVString>)> or USVString) init = ""),
  Exposed=(Window,Worker)]
 interface URLSearchParams {
   void append(USVString name, USVString value);
@@ -2803,9 +2803,17 @@ initially null.
   </ol>
 
  <li><p>Otherwise, if <var>init</var> is a <a>record</a>, then for each <a for=record>mapping</a>
- (<var>name</var>, <var>value</var>) in <var>init</var>, append a new name-value pair whose name is
- <var>name</var> and value is <var>value</var>, to <var>query</var>'s
- <a for=URLSearchParams>list</a>.
+ (<var>name</var>, <var>value</var>) in <var>init</var>, run these steps:
+
+ <ol>
+  <li><p>If <var>value</var> is a <a>sequence</a>, then for each <var>innerValue</var> in
+  <var>value</var>, append a new name-value pair whose name is <var>name</var> and value is
+  <var>innerValue</var>, to <var>query</var>'s <a for=URLSearchParams>list</a>.
+
+  <li><p>Otherwise, <var>value</var> is a string, then append a new name-value pair whose name is
+  <var>name</var> and value is <var>value</var>, to <var>query</var>'s
+  <a for=URLSearchParams>list</a>.
+ </ol>
 
  <li><p>Otherwise, <var>init</var> is a string, then set <var>query</var>'s
  <a for=URLSearchParams>list</a> to the result of


### PR DESCRIPTION
Now that #27 is merged, creation of `URLSearchParams` objects from an object/record has gotten a lot easier. However, one problem with the new syntax is that duplicated keys are not allowed with this new syntax.

I propose making the following change to the type of `init` parameter of the URLSearchParams constructor, so that more complex objects a la Node.js' [querystring](https://nodejs.org/api/querystring.html) module:

```diff
-(sequence<sequence<USVString>> or record<USVString,  USVString                        > or USVString)
+(sequence<sequence<USVString>> or record<USVString, (USVString or sequence<USVString>)> or USVString)
```

This way, Node.js users will be able to easily interoperate between `URLSearchParams` objects with native querystring module.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/TimothyGu/url/dup.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/31ddc5b..TimothyGu:dup:d9f74d3.html)