### PR TITLE
Fix: allow percent encoded code points in the non-special URLs host

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -282,6 +282,19 @@ U+0020,
 or
 "<code>]</code>".<!-- 5D -->
 
+<p>A <dfn export>forbidden opaque host code point</dfn> is
+U+0000,
+U+0009,
+U+000A,
+U+000D,
+U+0020,
+"<code>#</code>",<!-- 23 -->
+"<code>/</code>",<!-- 2F -->
+"<code>?</code>",<!-- 3F -->
+"<code>@</code>",<!-- 40 -->
+or
+"<code>\</code>".<!-- 5C -->
+
 
 <h3 id=idna>IDNA</h3>
 
@@ -1237,12 +1250,7 @@ and a boolean <var>isSpecial</var>, and then runs these steps:</p>
  <li><p>If <var>isSpecial</var> is true, then return the result of
  <a lt="host parser">host parsing</a> <var>input</var>.
 
- <li><p>Let <var>buffer</var> be the result of
- <a>UTF-8 decode without BOM</a> on the
- <a lt="percent decode">percent decoding</a> of
- <a>UTF-8 encode</a> on <var>input</var>.
-
- <li><p>If <var>buffer</var> contains a <a>forbidden host code point</a>, <a>syntax violation</a>,
+ <li><p>If <var>input</var> contains a <a>forbidden opaque host code point</a>, <a>syntax violation</a>,
  return failure.
 
  <li><p>Let <var>output</var> be the empty string.

--- a/url.bs
+++ b/url.bs
@@ -274,19 +274,6 @@ U+0020,
 or
 "<code>]</code>".<!-- 5D -->
 
-<p>A <dfn export>forbidden opaque host code point</dfn> is
-U+0000,
-U+0009,
-U+000A,
-U+000D,
-U+0020,
-"<code>#</code>",<!-- 23 -->
-"<code>/</code>",<!-- 2F -->
-"<code>?</code>",<!-- 3F -->
-"<code>@</code>",<!-- 40 -->
-or
-"<code>\</code>".<!-- 5C -->
-
 
 <h3 id=idna>IDNA</h3>
 
@@ -373,7 +360,7 @@ context to be distinguished.
 
 <h3 id=host-parsing>Host parsing</h3>
 
-<p>The <dfn id=concept-host-parser>host parser</dfn> takes a string <var>input</var> and
+<p>The <dfn id=concept-host-parser>host parser</dfn> takes a string <var>input</var>, a boolean <var>isSpecial</var> and
 an optional <var>Unicode flag</var> (unset unless stated otherwise), and then runs these
 steps:
 
@@ -391,6 +378,9 @@ steps:
    with its leading "<code>[</code>" and trailing
    "<code>]</code>" removed.
   </ol>
+
+ <li><p>If <var>isSpecial</var> is false, then return the result of
+ <a lt="opaque host parser">opaque host parsing</a> <var>input</var>.
 
  <li>
   <p>Let <var>domain</var> be the result of running <a>UTF-8 decode without BOM</a> on the
@@ -1248,14 +1238,11 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
 
 <hr>
 
-<p>The <dfn export id=concept-url-host-parser>URL-host parser</dfn> takes a string <var>input</var>
-and a boolean <var>isSpecial</var>, and then runs these steps:</p>
+<p>The <dfn export id=concept-opaque-host-parser>opaque host parser</dfn> takes a string <var>input</var>,
+and then runs these steps:</p>
 
 <ol>
- <li><p>If <var>isSpecial</var> is true, then return the result of
- <a lt="host parser">host parsing</a> <var>input</var>.
-
- <li><p>If <var>input</var> contains a <a>forbidden opaque host code point</a>, <a>syntax violation</a>,
+ <li><p>If <var>input</var> contains a <a>forbidden host code point</a> excluding "<code>%</code>", <a>syntax violation</a>,
  return failure.
 
  <li><p>Let <var>output</var> be the empty string.
@@ -1652,7 +1639,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
        <li><p>If <var>buffer</var> is the empty string, <a>syntax violation</a>, return failure.
        <!-- No URLs with port, but without host. -->
 
-       <li><p>Let <var>host</var> be the result of <a lt="URL-host parser">URL-host parsing</a>
+       <li><p>Let <var>host</var> be the result of <a lt="host parser">host parsing</a>
        <var>buffer</var> with <var>url</var> <a>is special</a>.
 
        <li><p>If <var>host</var> is failure, then return failure.
@@ -1682,7 +1669,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
        <!-- http://? -> failure
             test://? -> test://? -->
 
-       <li><p>Let <var>host</var> be the result of <a lt="URL-host parser">URL-host parsing</a>
+       <li><p>Let <var>host</var> be the result of <a lt="host parser">host parsing</a>
        <var>buffer</var> with <var>url</var> <a>is special</a>.
 
        <li><p>If <var>host</var> is failure, then return failure.
@@ -1878,7 +1865,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
         <ol>
          <li><p>Let <var>host</var> be the result of
          <a lt='host parser'>host parsing</a>
-         <var>buffer</var>.
+         <var>buffer</var> with <var>url</var> <a>is special</a>.
 
          <li><p>If <var>host</var> is failure, return failure.
 

--- a/url.bs
+++ b/url.bs
@@ -407,6 +407,21 @@ steps:
  result of running <a>domain to Unicode</a> on <var>asciiDomain</var> otherwise.
 </ol>
 
+The <dfn export id=concept-opaque-host-parser>opaque host parser</dfn> takes a string <var>input</var>,
+and then runs these steps:
+
+<ol>
+ <li><p>If <var>input</var> contains a <a>forbidden host code point</a> excluding "<code>%</code>", <a>syntax violation</a>,
+ return failure.
+
+ <li><p>Let <var>output</var> be the empty string.
+
+ <li><p>For each code point in <var>input</var>, <a>UTF-8 percent encode</a> it using the
+ <a>simple encode set</a>, and append the result to <var>output</var>.
+
+ <li><p>Return <var>output</var>.
+</ol>
+
 The <dfn>IPv4 number parser</dfn> takes a string <var>input</var> and a
 <var>syntaxViolationFlag</var> pointer, and then runs these steps:
 
@@ -1235,23 +1250,6 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
  <p>The base and output <a lt="URL record">URL</a> are represented in
  <a lt="URL serializer">serialized</a> form for brevity.
 </div>
-
-<hr>
-
-<p>The <dfn export id=concept-opaque-host-parser>opaque host parser</dfn> takes a string <var>input</var>,
-and then runs these steps:</p>
-
-<ol>
- <li><p>If <var>input</var> contains a <a>forbidden host code point</a> excluding "<code>%</code>", <a>syntax violation</a>,
- return failure.
-
- <li><p>Let <var>output</var> be the empty string.
-
- <li><p>For each code point in <var>input</var>, <a>UTF-8 percent encode</a> it using the
- <a>simple encode set</a>, and append the result to <var>output</var>.
-
- <li><p>Return <var>output</var>.
-</ol>
 
 <hr>
 

--- a/url.bs
+++ b/url.bs
@@ -360,9 +360,9 @@ context to be distinguished.
 
 <h3 id=host-parsing>Host parsing</h3>
 
-<p>The <dfn id=concept-host-parser>host parser</dfn> takes a string <var>input</var>, a boolean <var>isSpecial</var> and
-an optional <var>Unicode flag</var> (unset unless stated otherwise), and then runs these
-steps:
+<p>The <dfn id=concept-host-parser>host parser</dfn> takes a string <var>input</var>, a boolean
+<var>isSpecial</var>, and an optional <var>Unicode flag</var> (unset unless stated otherwise), and
+then runs these steps:
 
 <ol>
  <li>
@@ -380,7 +380,7 @@ steps:
   </ol>
 
  <li><p>If <var>isSpecial</var> is false, then return the result of
- <a lt="opaque host parser">opaque host parsing</a> <var>input</var>.
+ <a lt="opaque-host parser">opaque-host parsing</a> <var>input</var>.
 
  <li>
   <p>Let <var>domain</var> be the result of running <a>UTF-8 decode without BOM</a> on the
@@ -405,21 +405,6 @@ steps:
 
  <li><p>Return <var>asciiDomain</var> if the <var>Unicode flag</var> is unset, and the
  result of running <a>domain to Unicode</a> on <var>asciiDomain</var> otherwise.
-</ol>
-
-The <dfn export id=concept-opaque-host-parser>opaque host parser</dfn> takes a string <var>input</var>,
-and then runs these steps:
-
-<ol>
- <li><p>If <var>input</var> contains a <a>forbidden host code point</a> excluding "<code>%</code>", <a>syntax violation</a>,
- return failure.
-
- <li><p>Let <var>output</var> be the empty string.
-
- <li><p>For each code point in <var>input</var>, <a>UTF-8 percent encode</a> it using the
- <a>simple encode set</a>, and append the result to <var>output</var>.
-
- <li><p>Return <var>output</var>.
 </ol>
 
 The <dfn>IPv4 number parser</dfn> takes a string <var>input</var> and a
@@ -467,8 +452,10 @@ The <dfn>IPv4 number parser</dfn> takes a string <var>input</var> and a
  <!-- XXX well, you know, it works for ECMAScript, kinda -->
 </ol>
 
-The <dfn id=concept-ipv4-parser>IPv4 parser</dfn> takes a string <var>input</var> and then
-runs these steps:
+<hr>
+
+<p>The <dfn id=concept-ipv4-parser>IPv4 parser</dfn> takes a string <var>input</var> and then runs
+these steps:
 
 <ol>
  <li><p>Let <var>syntaxViolationFlag</var> be unset.
@@ -538,6 +525,8 @@ runs these steps:
 
  <li><p>Return <var>ipv4</var>.
 </ol>
+
+<hr>
 
 <p>The <dfn id=concept-ipv6-parser>IPv6 parser</dfn> takes a string <var>input</var> and
 then runs these steps:
@@ -719,6 +708,23 @@ then runs these steps:
 <p class="note no-backref">To be clear, <a lt='IPv6 parser Main'>Main</a>,
 <a lt='IPv6 parser IPv4'>IPv4</a>, and <a lt='IPv6 parser Finale'>Finale</a> are markers. They serve
 no purpose other than being a location the algorithm can jump to.
+
+<hr>
+
+<p>The <dfn export id=concept-opaque-host-parser>opaque-host parser</dfn> takes a string
+<var>input</var>, and then runs these steps:
+
+<ol>
+ <li><p>If <var>input</var> contains a <a>forbidden host code point</a> excluding "<code>%</code>",
+ <a>syntax violation</a>, return failure.
+
+ <li><p>Let <var>output</var> be the empty string.
+
+ <li><p>For each code point in <var>input</var>, <a>UTF-8 percent encode</a> it using the
+ <a>simple encode set</a>, and append the result to <var>output</var>.
+
+ <li><p>Return <var>output</var>.
+</ol>
 
 
 <h3 id=host-serializing>Host serializing</h3>
@@ -1861,8 +1867,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
         <p>Otherwise, run these steps:
 
         <ol>
-         <li><p>Let <var>host</var> be the result of
-         <a lt='host parser'>host parsing</a>
+         <li><p>Let <var>host</var> be the result of <a lt="host parser">host parsing</a>
          <var>buffer</var> with <var>url</var> <a>is special</a>.
 
          <li><p>If <var>host</var> is failure, return failure.

--- a/url.bs
+++ b/url.bs
@@ -1237,7 +1237,12 @@ and a boolean <var>isSpecial</var>, and then runs these steps:</p>
  <li><p>If <var>isSpecial</var> is true, then return the result of
  <a lt="host parser">host parsing</a> <var>input</var>.
 
- <li><p>If <var>input</var> contains a <a>forbidden host code point</a>, <a>syntax violation</a>,
+ <li><p>Let <var>buffer</var> be the result of
+ <a>UTF-8 decode without BOM</a> on the
+ <a lt="percent decode">percent decoding</a> of
+ <a>UTF-8 encode</a> on <var>input</var>.
+
+ <li><p>If <var>buffer</var> contains a <a>forbidden host code point</a>, <a>syntax violation</a>,
  return failure.
 
  <li><p>Let <var>output</var> be the empty string.


### PR DESCRIPTION
After 30362553e9ce9fc706d3492bd61886e399fc94e2 introduced the [URL-host parser](https://url.spec.whatwg.org/commit-snapshots/30362553e9ce9fc706d3492bd61886e399fc94e2/#concept-url-host-parser) rejects percent encoded code points in the non-special URLs host (because "%" is [forbidden host code point](https://url.spec.whatwg.org/#forbidden-host-code-point)).

The situation is paradoxical, because parser himself percent encodes some code points, actually producing invalid serialized URLs according to the current standard. 

URL's from #148 to test issue:
`unknown://%E2%80%A0/`
`notspecial://H%4fSt/path`

**Solution**
I suggest that forbidden host code points be checked on percent decoded code points. The decoded data will be used only for this purpose, so the <var>output</var> will not be affected by this change.

Also this is a closer to [special URLs host validity check](https://url.spec.whatwg.org/#concept-host-parser).