### PR TITLE
Repeated slashes should be ignored in file scheme

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1570,23 +1570,14 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
         <p>If <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>", run these
         subsubsteps:
         <ol>
-         <li>
-          <p>If <a>remaining</a> does not start with "<code>//</code>",
-          <a>syntax violation</a>.</p>
-         </li>
-         <li>
-          <p>Set <var>state</var> to <a>file state</a>,
-          and decrease <var>pointer</var> by one.</p>
-         </li>
+         <li><p>If <a>remaining</a> does not start with "<code>//</code>",
+         <a>syntax violation</a>.
+         <li><p>Set <var>state</var> to <a>file state</a>.
         </ol>
-       <li>
-        <p>Otherwise, set <var>state</var>
-        to <a>authority state</a>, and decrease <var>pointer</var> by one.</p>
-       </li>
+       <li><p>Otherwise, set <var>state</var> to <a>authority state</a>.
+       <li><p>Decrease <var>pointer</var> by one.
       </ol>
-     <li>
-      <p>Otherwise, <a>syntax violation</a>.</p>
-     </li>
+     <li><p>Otherwise, <a>syntax violation</a>.
     </ol>
    </dd>
    <dt><dfn>authority state</dfn>

--- a/url.bs
+++ b/url.bs
@@ -1358,21 +1358,22 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
        <li><p>If <var>state override</var> is given, terminate this algorithm.
 
        <li>
-        <p>If <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>", run these
-        subsubsteps:
-
-        <ol>
-         <li><p>If <a>remaining</a> does not start with "<code>//</code>",
-         <a>syntax violation</a>.
-
-         <li><p>Set <var>state</var> to <a>file state</a>.
-        </ol>
-
-       <li>
         <p>Otherwise, if <var>url</var> <a>is special</a>, <var>base</var> is non-null, and
-        <var>base</var>'s <a for=url>scheme</a> is equal to <var>url</var>'s <a for=url>scheme</a>,
-        set <var>state</var> to <a>special relative or authority state</a>.
-
+        <var>base</var>'s <a for=url>scheme</a> is equal to <var>url</var>'s
+        <a for=url>scheme</a>, run these subsubsteps:</p>
+        <ol>
+         <li>
+          <p>If <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>", run these
+           subsubsteps:</p>
+           <ol>
+            <li><p>If <a>remaining</a> does not start with "<code>//</code>",
+             <a>syntax violation</a>.</p></li>
+            <li><p>Set <var>state</var> to <a>file state</a>.</p></li>
+          </ol>
+         <li>
+          <p>Otherwise, set <var>state</var> to <a>special relative or authority state</a>.</p>
+         </li>
+        </ol>
         <p class="note no-backref">This means that <var>base</var>'s
         <a for=url>cannot-be-a-base-URL flag</a> is unset.
 
@@ -1561,11 +1562,33 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
 
    <dt><dfn>special authority ignore slashes state</dfn>
    <dd>
-    <p>If <a>c</a> is neither "<code>/</code>" nor "<code>\</code>", set <var>state</var>
-    to <a>authority state</a>, and decrease <var>pointer</var> by one.
-
-    <p>Otherwise, <a>syntax violation</a>.
-
+    <ol>
+     <li>
+      <p>If <a>c</a> is neither "<code>/</code>" nor "<code>\</code>", run these substeps:
+      <ol>
+       <li>
+        <p>If <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>", run these
+        subsubsteps:
+        <ol>
+         <li>
+          <p>If <a>remaining</a> does not start with "<code>//</code>",
+          <a>syntax violation</a>.</p>
+         </li>
+         <li>
+          <p>Set <var>state</var> to <a>file state</a>,
+          and decrease <var>pointer</var> by one.</p>
+         </li>
+        </ol>
+       <li>
+        <p>Otherwise, set <var>state</var>
+        to <a>authority state</a>, and decrease <var>pointer</var> by one.</p>
+       </li>
+      </ol>
+     <li>
+      <p>Otherwise, <a>syntax violation</a>.</p>
+     </li>
+    </ol>
+   </dd>
    <dt><dfn>authority state</dfn>
    <dd>
     <ol>


### PR DESCRIPTION
Fixes https://github.com/whatwg/url/issues/232.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/watilde/url/feature/check-file-slashes.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/6688baa..watilde:feature/check-file-slashes:b46bf40.html)