### PR TITLE
Make IPv6 addresses in special URLs valid

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -382,7 +382,8 @@ up to three <a>ASCII digits</a> per sequence, each representing a decimal number
 
      XXX should we define the format inline instead just like STD 66? -->
 
-<p>A <dfn export>valid opaque-host string</dfn> must be zero or more <a>URL units</a>.
+<p>An <dfn export>valid opaque-host string</dfn> must be zero or more <a>URL units</a> or:
+"<code>[</code>", followed by an <a>IPv6 address string</a>, followed by "<code>]</code>".
 
 <p class="note no-backref">This is not part of the definition of <a>valid host string</a> as it
 requires context to be distinguished.


### PR DESCRIPTION
I forgot about this in #218.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://url.spec.whatwg.org//branch-snapshots/annevk/valid-non-special-ipv6/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/50cb9ab..annevk/valid-non-special-ipv6:b33172b.html)