### PR TITLE
Use Nontransitional_Processing for IDNA ToASCII

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -286,11 +286,10 @@ or
 <a>domain</a> <var>domain</var>, runs these steps:
 
 <ol>
- <li><p>Let <var>result</var> be the result of running
- <a lt=ToASCII>Unicode ToASCII</a> with
- <i>domain_name</i> set to <var>domain</var>,
- <i>UseSTD3ASCIIRules</i> set to false, <i>processing_option</i> set to
- <i>Transitional_Processing</i>, and <i>VerifyDnsLength</i> set to false.
+ <li><p>Let <var>result</var> be the result of running <a lt=ToASCII>Unicode ToASCII</a> with
+ <i>domain_name</i> set to <var>domain</var>, <i>UseSTD3ASCIIRules</i> set to false,
+ <i>processing_option</i> set to <i>Nontransitional_Processing</i>, and <i>VerifyDnsLength</i> set
+ to false.
 
  <li><p>If <var>result</var> is a failure value, <a>syntax violation</a>, return failure.
 


### PR DESCRIPTION
This is implemented by Firefox and Safari without much trouble. The
hope is that other browsers and user agents will follow suit.

Tests: https://github.com/w3c/web-platform-tests/pull/4771.

Fixes #239.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://url.spec.whatwg.org/branch-snapshots/annevk/Nontransitional/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/2b3c864..annevk/Nontransitional:896aeff.html)