### PR TITLE
Define which URLs are valid in the parser examples

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -894,7 +894,7 @@ unified model would be, please file an issue.
   <tr>
    <td><code>https:example.org</code>
    <td>
-   <td>✅
+   <td>❌
    <td><code>https://example.org/</code>
   <tr>
    <td><code>https://////example.com///</code>

--- a/url.bs
+++ b/url.bs
@@ -942,6 +942,26 @@ unified model would be, please file an issue.
    <td>✅
    <td><code>file:///</code>
   <tr>
+   <td><code>https://user:password@example.org/</code>
+   <td>
+   <td>❌
+   <td><code>https://user:password@example.org/</code>
+  <tr>
+   <td><code>https://example.org/foo bar</code>
+   <td>
+   <td>❌
+   <td><code>https://example.org/foo%20bar</code>
+  <tr>
+   <td><code>https://EXAMPLE.com/../x</code>
+   <td>
+   <td>✅
+   <td><code>https://example.com/x</code>
+  <tr>
+   <td><code>https://ex ample.org/</code>
+   <td>
+   <td>❌
+   <td>Failure
+  <tr>
    <td><code>example</code>
    <td>
    <td>❌, due to lack of base

--- a/url.bs
+++ b/url.bs
@@ -884,6 +884,58 @@ unified model would be, please file an issue.
  that was <a lt="URL serializer">serialized</a>.)
 </ul>
 
+<div class=example id=example-url-parsing>
+ <table>
+  <tr>
+   <th>Input (valid)
+   <th>Base
+   <th>Output
+  <tr>
+   <td><code>https:example.org</code> (✅)
+   <td>
+   <td><code>https://example.org/</code>
+  <tr>
+   <td><code>https://////example.com///</code> (❌)
+   <td>
+   <td><code>https://example.com///</code>
+  <tr>
+   <td><code>https://example.com/././foo</code> (✅)
+   <td>
+   <td><code>https://example.com/foo</code>
+  <tr>
+   <td><code>hello:world</code> (✅)
+   <td><code>https://example.com/</code>
+   <td><code>hello:world</code>
+  <tr>
+   <td><code>https:example.org</code> (❌)
+   <td><code>https://example.com/</code>
+   <td><code>https://example.com/example.org</code>
+  <tr>
+   <td><code>\example\..\demo/.\</code> (❌)
+   <td><code>https://example.com/</code>
+   <td><code>https://example.com/demo/</code>
+  <tr>
+   <td><code>example</code> (✅)
+   <td><code>https://example.com/demo</code>
+   <td><code>https://example.com/example</code>
+  <tr>
+   <td><code>example</code> (❌, due to lack of base)
+   <td>
+   <td>Failure
+  <tr>
+   <td><code>https://example.com:demo</code> (❌)
+   <td>
+   <td>Failure
+  <tr>
+   <td><code>http://[www.example.com]/</code> (❌)
+   <td>
+   <td>Failure
+ </table>
+
+ <p>The base and output <a lt="URL record">URL</a> are represented in
+ <a lt="URL serializer">serialized</a> form for brevity.
+</div>
+
 
 <h3 id=url-representation>URL representation</h3>
 
@@ -1156,7 +1208,7 @@ following
 <a>ASCII alphanumeric</a>,
 "<code>!</code>",<!-- 0x21, sub-delims -->
 "<code>$</code>",<!-- 0x24, sub-delims -->
-"<code>&</code>",<!-- 0x26, sub-delims -->
+"<code>&amp;</code>",<!-- 0x26, sub-delims -->
 "<code>'</code>",<!-- 0x27, sub-delims -->
 "<code>(</code>",<!-- 0x28, sub-delims -->
 "<code>)</code>",<!-- 0x29, sub-delims -->
@@ -1260,58 +1312,6 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
 
  <li><p>Return <var>url</var>.
 </ol>
-
-<div class=example id=example-url-parsing>
- <table>
-  <tr>
-   <th>Input
-   <th>Base
-   <th>Output
-  <tr>
-   <td><code>https:example.org</code>
-   <td>
-   <td><code>https://example.org/</code>
-  <tr>
-   <td><code>https://////example.com///</code>
-   <td>
-   <td><code>https://example.com///</code>
-  <tr>
-   <td><code>https://example.com/././foo</code>
-   <td>
-   <td><code>https://example.com/foo</code>
-  <tr>
-   <td><code>hello:world</code>
-   <td><code>https://example.com</code>
-   <td><code>hello:world</code>
-  <tr>
-   <td><code>https:example.org</code>
-   <td><code>https://example.com</code>
-   <td><code>https://example.com/example.org</code>
-  <tr>
-   <td><code>\example\..\demo/.\</code>
-   <td><code>https://example.com</code>
-   <td><code>https://example.com/demo/</code>
-  <tr>
-   <td><code>example</code>
-   <td><code>https://example.com/demo</code>
-   <td><code>https://example.com/example</code>
-  <tr>
-   <td><code>example</code>
-   <td>
-   <td>Failure
-  <tr>
-   <td><code>https://example.com:demo</code>
-   <td>
-   <td>Failure
-  <tr>
-   <td><code>http://[www.example.com]/</code>
-   <td>
-   <td>Failure
- </table>
-
- <p>The base and output <a lt="URL record">URL</a> are represented in
- <a lt="URL serializer">serialized</a> form for brevity.
-</div>
 
 <hr>
 

--- a/url.bs
+++ b/url.bs
@@ -887,60 +887,74 @@ unified model would be, please file an issue.
 <div class=example id=example-url-parsing>
  <table>
   <tr>
-   <th>Input (valid)
+   <th>Input
    <th>Base
+   <th>Valid
    <th>Output
   <tr>
-   <td><code>https:example.org</code> (✅)
+   <td><code>https:example.org</code>
    <td>
+   <td>✅
    <td><code>https://example.org/</code>
   <tr>
-   <td><code>https://////example.com///</code> (❌)
+   <td><code>https://////example.com///</code>
    <td>
+   <td>❌
    <td><code>https://example.com///</code>
   <tr>
-   <td><code>https://example.com/././foo</code> (✅)
+   <td><code>https://example.com/././foo</code>
    <td>
+   <td>✅
    <td><code>https://example.com/foo</code>
   <tr>
-   <td><code>hello:world</code> (✅)
+   <td><code>hello:world</code>
    <td><code>https://example.com/</code>
+   <td>✅
    <td><code>hello:world</code>
   <tr>
-   <td><code>https:example.org</code> (❌)
+   <td><code>https:example.org</code>
    <td><code>https://example.com/</code>
+   <td>❌
    <td><code>https://example.com/example.org</code>
   <tr>
-   <td><code>\example\..\demo/.\</code> (❌)
+   <td><code>\example\..\demo/.\</code>
    <td><code>https://example.com/</code>
+   <td>❌
    <td><code>https://example.com/demo/</code>
   <tr>
-   <td><code>example</code> (✅)
+   <td><code>example</code>
    <td><code>https://example.com/demo</code>
+   <td>✅
    <td><code>https://example.com/example</code>
   <tr>
-   <td><code>file:///C|/demo</code> (❌)
+   <td><code>file:///C|/demo</code>
    <td>
+   <td>❌
    <td><code>file:///C:/demo</code>
   <tr>
-   <td><code>..</code> (✅)
+   <td><code>..</code>
    <td><code>file:///C:/demo</code>
+   <td>✅
    <td><code>file:///C:/</code>
   <tr>
-   <td><code>file://loc%61lhost/</code> (✅)
+   <td><code>file://loc%61lhost/</code>
    <td>
+   <td>✅
    <td><code>file:///</code>
   <tr>
-   <td><code>example</code> (❌, due to lack of base)
+   <td><code>example</code>
    <td>
+   <td>❌, due to lack of base
    <td>Failure
   <tr>
-   <td><code>https://example.com:demo</code> (❌)
+   <td><code>https://example.com:demo</code>
    <td>
+   <td>❌
    <td>Failure
   <tr>
-   <td><code>http://[www.example.com]/</code> (❌)
+   <td><code>http://[www.example.com]/</code>
    <td>
+   <td>❌
    <td>Failure
  </table>
 

--- a/url.bs
+++ b/url.bs
@@ -919,6 +919,18 @@ unified model would be, please file an issue.
    <td><code>https://example.com/demo</code>
    <td><code>https://example.com/example</code>
   <tr>
+   <td><code>file:///C|/demo</code> (❌)
+   <td>
+   <td><code>file:///C:/demo</code>
+  <tr>
+   <td><code>..</code> (✅)
+   <td><code>file:///C:/demo</code>
+   <td><code>file:///C:/</code>
+  <tr>
+   <td><code>file://loc%61lhost/</code> (✅)
+   <td>
+   <td><code>file:///</code>
+  <tr>
    <td><code>example</code> (❌, due to lack of base)
    <td>
    <td>Failure


### PR DESCRIPTION
Also make sure the base URLs are actually represented in serialized
form by adding trailing slashes.

Fixes #209.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://url.spec.whatwg.org//branch-snapshots/annevk/validity-example/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/50cb9ab..annevk/validity-example:4000ed7.html)