### PR TITLE
Paths need to be copied from base URLs

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2086,7 +2086,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
        not start with two <a>ASCII hex digits</a>, <a>validation error</a>.
 
        <li><p>If <a>c</a> is not <a>EOF code point</a>, <a>UTF-8 percent encode</a> <a>c</a> using
-       the <a>simple encode set</a>, and <a for=list>append</a> the result to <var>url</var>'s
+       the <a>simple encode set</a>, and append the result to <var>url</var>'s
        <a for=url>path</a>[0].
       </ol>
     </ol>

--- a/url.bs
+++ b/url.bs
@@ -1017,7 +1017,7 @@ code point is "<code>:</code>".
 <ol>
  <li><p>Let <var>path</var> be <var>url</var>'s <a for=url>path</a>.
 
- <li><p>If <var>path</var>'s <a for=list>size</a> is 0, then return.
+ <li><p>If <var>path</var> <a for=list>is empty</a>, then return.
 
  <li><p>If <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>", <var>path</var>'s
  <a for=list>size</a> is 1, and <var>path</var>[0] is a <a>normalized Windows drive letter</a>, then
@@ -1471,7 +1471,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
      <li><p>Otherwise, if <var>base</var>'s <a for=url>cannot-be-a-base-URL flag</a> is set and
      <a>c</a> is "<code>#</code>", set <var>url</var>'s <a for=url>scheme</a> to
      <var>base</var>'s <a for=url>scheme</a>,
-     <var>url</var>'s <a for=url>path</a> to
+     <var>url</var>'s <a for=url>path</a> to a copy of
      <var>base</var>'s <a for=url>path</a>,
      <var>url</var>'s <a for=url>query</a> to
      <var>base</var>'s <a for=url>query</a>,
@@ -1519,7 +1519,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
      <var>base</var>'s <a for=url>host</a>,
      <var>url</var>'s <a for=url>port</a> to
      <var>base</var>'s <a for=url>port</a>,
-     <var>url</var>'s <a for=url>path</a> to
+     <var>url</var>'s <a for=url>path</a> to a copy of
      <var>base</var>'s <a for=url>path</a>, and
      <var>url</var>'s <a for=url>query</a> to
      <var>base</var>'s <a for=url>query</a>.
@@ -1536,7 +1536,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
      <var>base</var>'s <a for=url>host</a>,
      <var>url</var>'s <a for=url>port</a> to
      <var>base</var>'s <a for=url>port</a>,
-     <var>url</var>'s <a for=url>path</a> to
+     <var>url</var>'s <a for=url>path</a> to a copy of
      <var>base</var>'s <a for=url>path</a>,
      <var>url</var>'s <a for=url>query</a> to the empty string,
      and <var>state</var> to <a>query state</a>.
@@ -1550,7 +1550,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
      <var>base</var>'s <a for=url>host</a>,
      <var>url</var>'s <a for=url>port</a> to
      <var>base</var>'s <a for=url>port</a>,
-     <var>url</var>'s <a for=url>path</a> to
+     <var>url</var>'s <a for=url>path</a> to a copy of
      <var>base</var>'s <a for=url>path</a>,
      <var>url</var>'s <a for=url>query</a> to
      <var>base</var>'s <a for=url>query</a>,
@@ -1573,7 +1573,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
        <var>base</var>'s <a for=url>host</a>,
        <var>url</var>'s <a for=url>port</a> to
        <var>base</var>'s <a for=url>port</a>,
-       <var>url</var>'s <a for=url>path</a> to
+       <var>url</var>'s <a for=url>path</a> to a copy of
        <var>base</var>'s <a for=url>path</a>, and then <a for=list>remove</a>
        <var>url</var>'s <a for=url>path</a>'s last item, if any.
 
@@ -1827,18 +1827,18 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
       <dl class=switch>
        <dt><a>EOF code point</a>
        <dd><p>Set <var>url</var>'s <a for=url>host</a> to <var>base</var>'s <a for=url>host</a>,
-       <var>url</var>'s <a for=url>path</a> to <var>base</var>'s <a for=url>path</a>, and
+       <var>url</var>'s <a for=url>path</a> to a copy of <var>base</var>'s <a for=url>path</a>, and
        <var>url</var>'s <a for=url>query</a> to <var>base</var>'s <a for=url>query</a>.
 
        <dt>"<code>?</code>"
        <dd><p>Set <var>url</var>'s <a for=url>host</a> to <var>base</var>'s <a for=url>host</a>,
-       <var>url</var>'s <a for=url>path</a> to <var>base</var>'s <a for=url>path</a>,
+       <var>url</var>'s <a for=url>path</a> to a copy of <var>base</var>'s <a for=url>path</a>,
        <var>url</var>'s <a for=url>query</a> to the empty string, and <var>state</var> to
        <a>query state</a>.
 
        <dt>"<code>#</code>"
        <dd><p>Set <var>url</var>'s <a for=url>host</a> to <var>base</var>'s <a for=url>host</a>,
-       <var>url</var>'s <a for=url>path</a> to <var>base</var>'s <a for=url>path</a>,
+       <var>url</var>'s <a for=url>path</a> to a copy of <var>base</var>'s <a for=url>path</a>,
        <var>url</var>'s <a for=url>query</a> to <var>base</var>'s <a for=url>query</a>,
        <var>url</var>'s <a for=url>fragment</a> to the empty string, and <var>state</var> to
        <a>fragment state</a>.
@@ -1858,8 +1858,8 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
           </ul>
 
           <p>then set <var>url</var>'s <a for=url>host</a> to <var>base</var>'s <a for=url>host</a>,
-          <var>url</var>'s <a for=url>path</a> to <var>base</var>'s <a for=url>path</a>, and then
-          <a>shorten</a> <var>url</var>'s <a for=url>path</a>.
+          <var>url</var>'s <a for=url>path</a> to a copy of <var>base</var>'s <a for=url>path</a>,
+          and then <a>shorten</a> <var>url</var>'s <a for=url>path</a>.
 
           <p class=note>This is a (platform-independent) Windows drive letter quirk.
 
@@ -2086,8 +2086,8 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
        not start with two <a>ASCII hex digits</a>, <a>validation error</a>.
 
        <li><p>If <a>c</a> is not <a>EOF code point</a>, <a>UTF-8 percent encode</a> <a>c</a> using
-       the <a>simple encode set</a>, and <a for=list>append</a> the result to the first string in
-       <var>url</var>'s <a for=url>path</a>.
+       the <a>simple encode set</a>, and <a for=list>append</a> the result to <var>url</var>'s
+       <a for=url>path</a>[0].
       </ol>
     </ol>
 


### PR DESCRIPTION
Otherwise things get a little weird.

Fixes #231.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://url.spec.whatwg.org//branch-snapshots/annevk/copy-paths/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/50cb9ab..annevk/copy-paths:fd8895f.html)