### PR TITLE
A file URL cannot have credentials

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1971,9 +1971,6 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
         <p>Otherwise, if <var>buffer</var> is the empty string, then:
 
         <ol>
-         <li><p>If <var>state override</var> is given and <var>url</var>
-         <a>includes credentials</a>, <a>validation error</a>, return.
-
          <li><p>Set <var>url</var>'s <a for=url>host</a> to the empty string.
 
          <li><p>If <var>state override</var> is given, then return.


### PR DESCRIPTION
Remove “dead code” found through
https://github.com/w3c/web-platform-tests/issues/3018. (Note that the
API username/password setters are also no-ops for file URLs.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://url.spec.whatwg.org/branch-snapshots/annevk/no-file-url-with-credentials/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/6463c12..annevk/no-file-url-with-credentials:9dbbfaa.html)