### PR TITLE
Remove javascript URL special case from the API

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2909,9 +2909,6 @@ getter must run these steps:
 steps:
 
 <ol>
- <li><p>If <a>context object</a>'s <a for=URL>url</a>'s <a for=url>scheme</a> is
- "<code>javascript</code>", then return.
-
  <li><p>If the given value is the empty string, then set <a>context object</a>'s
  <a for=URL>url</a>'s <a for=url>fragment</a> to null and return.
 


### PR DESCRIPTION
Fixes #253.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://url.spec.whatwg.org/branch-snapshots/annevk/hash-javascript/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/6463c12..annevk/hash-javascript:b039de5.html)