### PR TITLE
Use empty host for file URL's

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -385,7 +385,7 @@ up to three <a>ASCII digits</a> per sequence, each representing a decimal number
 
      XXX should we define the format inline instead just like STD 66? -->
 
-<p>An <dfn export>valid opaque-host string</dfn> must be one or more <a>URL units</a> or:
+<p>A <dfn export>valid opaque-host string</dfn> must be one or more <a>URL units</a> or:
 "<code>[</code>", followed by a <a>valid IPv6-address string</a>, followed by "<code>]</code>".
 
 <p class="note no-backref">This is not part of the definition of <a>valid host string</a> as it
@@ -770,8 +770,8 @@ no purpose other than being a location the algorithm can jump to.
  <a>IPv6 serializer</a> on <var>host</var>,
  followed by "<code>]</code>".
 
- <li><p>Otherwise, <var>host</var> is a <a>domain</a>, an <a>opaque host</a>, or an <a>empty
- host</a>, return <var>host</var>.
+ <li><p>Otherwise, <var>host</var> is a <a>domain</a>, <a>opaque host</a>, or <a>empty host</a>,
+ return <var>host</var>.
 </ol>
 
 The <dfn id=concept-ipv4-serializer>IPv4 serializer</dfn> takes an
@@ -1175,8 +1175,8 @@ switching on <a>base URL</a>'s <a for=url>scheme</a>:
  <dd><p>a <a>path-relative-scheme-less-URL string</a>
  <dt>"<code>file</code>"
  <dd><p>a <a>scheme-relative-file-URL string</a>
- <dd><p>a <a>path-absolute-URL string</a> if <a>base URL</a>'s <a for=url>host</a> is an <a>empty
- host</a>
+ <dd><p>a <a>path-absolute-URL string</a> if <a>base URL</a>'s <a for=url>host</a> is an
+ <a>empty host</a>
  <dd><p>a <a>path-absolute-non-Windows-file-URL string</a> if <a>base URL</a>'s <a for=url>host</a>
  is not an <a>empty host</a>
  <dd><p>a <a>path-relative-scheme-less-URL string</a>
@@ -2073,8 +2073,8 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
            <li><p>If <var>url</var>'s <a for=url>host</a> is not the empty string,
            <a>validation error</a>.
 
-           <li><p>Set <var>url</var>'s <a for=url>host</a> to the empty string and replace the second
-           code point in <var>buffer</var> with "<code>:</code>".
+           <li><p>Set <var>url</var>'s <a for=url>host</a> to the empty string and replace the
+           second code point in <var>buffer</var> with "<code>:</code>".
           </ol>
 
           <p class=note>This is a (platform-independent) Windows drive letter quirk.

--- a/url.bs
+++ b/url.bs
@@ -283,9 +283,6 @@ eight <dfn id=concept-ipv6-piece lt='IPv6 piece'>16-bit pieces</dfn>.
 <p>An <dfn export>opaque host</dfn> is a non-empty <a>ASCII string</a> holding data that can be used
 for further processing.
 
-<p class="note no-backref">An <a>opaque host</a> is only used by <a lt="is special">non-special</a>
-<a for=/>URLs</a>.
-
 <p>An <dfn export>empty host</dfn> is the empty string.
 
 
@@ -1010,17 +1007,40 @@ It is initially the empty string.
  <a for=url>host</a> combinations.
 
  <table>
-  <tr><th rowspan="2"><a for=/>URL</a>'s <a for=url>scheme</a>
-      <th colspan="6"><a for=/>URL</a>'s <a for=url>host</a>
-  <tr><th><a>domain</a>
-      <th><a>IPv4 address</a>
-      <th><a>IPv6 address</a>
-      <th><a>opaque host</a>
-      <th><a>empty host</a>
-      <th>null
-  <tr><td>non-file <a lt="special scheme">special</a><td>✅<td>✅<td>✅<td><td><td>
-  <tr><td>"<code>file</code>"<td>✅<td>✅<td>✅<td><td>✅<td>✅
-  <tr><td><a lt="special scheme">non-special</a><td><td><td>✅<td>✅<td>✅<td>✅
+  <tr>
+   <th rowspan=2><a for=url>scheme</a>
+   <th colspan=6><a for=url>host</a>
+  <tr>
+   <th><a>domain</a>
+   <th><a>IPv4 address</a>
+   <th><a>IPv6 address</a>
+   <th><a>opaque host</a>
+   <th><a>empty host</a>
+   <th>null
+  <tr>
+   <td>non-"<code>file</code>" <a lt="special scheme">special</a>
+   <td>✅
+   <td>✅
+   <td>✅
+   <td>❌
+   <td>❌
+   <td>❌
+  <tr>
+   <td>"<code>file</code>"
+   <td>✅
+   <td>✅
+   <td>✅
+   <td>❌
+   <td>✅
+   <td>✅
+  <tr>
+   <td><a lt="special scheme">non-special</a>
+   <td>❌
+   <td>❌
+   <td>✅
+   <td>✅
+   <td>✅
+   <td>✅
  </table>
 </div>
 

--- a/url.bs
+++ b/url.bs
@@ -280,7 +280,7 @@ eight <dfn id=concept-ipv6-piece lt='IPv6 piece'>16-bit pieces</dfn>.
 <p class="note">Support for <code>&lt;zone_id></code> is
 <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=27234#c2">intentionally omitted</a>.
 
-<p>An <dfn export>opaque host</dfn> is an <a>ASCII string</a> holding data that can be used for
+<p>An <dfn export>opaque host</dfn> is a non-empty <a>ASCII string</a> holding data that can be used for
 further processing.
 
 <p class="note no-backref">An <a>opaque host</a> is only used by <a lt="is special">non-special</a>
@@ -385,7 +385,7 @@ up to three <a>ASCII digits</a> per sequence, each representing a decimal number
 
      XXX should we define the format inline instead just like STD 66? -->
 
-<p>An <dfn export>valid opaque-host string</dfn> must be zero or more <a>URL units</a> or:
+<p>An <dfn export>valid opaque-host string</dfn> must be one or more <a>URL units</a> or:
 "<code>[</code>", followed by a <a>valid IPv6-address string</a>, followed by "<code>]</code>".
 
 <p class="note no-backref">This is not part of the definition of <a>valid host string</a> as it
@@ -1201,7 +1201,7 @@ optionally followed by a <a>path-absolute-URL string</a>.
 <a>path-absolute-URL string</a>.
 
 <p>An <dfn export>opaque-host-and-port string</dfn> must be either an empty
-<a>valid opaque-host string</a> or: a non-empty <a>valid opaque-host string</a>, optionally followed
+string or: a <a>valid opaque-host string</a>, optionally followed
 by "<code>:</code>" and a <a>URL-port string</a>.
 
 <p>A <dfn export oldids=syntax-url-file-scheme-relative>scheme-relative-file-URL string</dfn> must be

--- a/url.bs
+++ b/url.bs
@@ -1005,6 +1005,25 @@ It is initially the empty string.
 <p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-host>host</dfn> is null or a
 <a for=/>host</a>. It is initially null.
 
+<div class="note">
+ <p>The following table lists allowed <a for=/>URL</a>'s <a for=url>scheme</a> /
+ <a for=url>host</a> combinations.
+
+ <table>
+  <tr><th rowspan="2"><a for=/>URL</a>'s <a for=url>scheme</a>
+      <th colspan="6"><a for=/>URL</a>'s <a for=url>host</a>
+  <tr><th><a>domain</a>
+      <th><a>IPv4 address</a>
+      <th><a>IPv6 address</a>
+      <th><a>opaque host</a>
+      <th><a>empty host</a>
+      <th>null
+  <tr><td>non-file <a lt="special scheme">special</a><td>✅<td>✅<td>✅<td><td><td>
+  <tr><td>"<code>file</code>"<td>✅<td>✅<td>✅<td><td>✅<td>✅
+  <tr><td><a lt="special scheme">non-special</a><td><td><td>✅<td>✅<td>✅<td>✅
+ </table>
+</div>
+
 <p>A  <a for=/>URL</a>'s <dfn export for=url id=concept-url-port>port</dfn> is either
 null or a 16-bit unsigned integer that identifies a networking port. It is initially null.
 

--- a/url.bs
+++ b/url.bs
@@ -254,7 +254,7 @@ point <a for=/>URLs</a> from <var>A</var> can come from untrusted sources.
 <h3 id=host-representation>Host representation</h3>
 
 <p>A <dfn export id=concept-host>host</dfn> is a <a>domain</a>, an
-<a>IPv4 address</a>, an <a>IPv6 address</a>, or an <a>opaque host</a>. Typically a <a for=/>host</a>
+<a>IPv4 address</a>, an <a>IPv6 address</a>, an <a>opaque host</a>, or an <a>empty host</a>. Typically a <a for=/>host</a>
 serves as a network address, but it is sometimes used as opaque identifier in <a for=/>URLs</a>
 where a network address is not necessary.
 
@@ -285,6 +285,8 @@ further processing.
 
 <p class="note no-backref">An <a>opaque host</a> is only used by <a lt="is special">non-special</a>
 <a for=/>URLs</a>.
+
+<p>An <dfn export>empty host</dfn> is the empty string.
 
 
 <h3 id=host-miscellaneous>Host miscellaneous</h3>
@@ -768,7 +770,7 @@ no purpose other than being a location the algorithm can jump to.
  <a>IPv6 serializer</a> on <var>host</var>,
  followed by "<code>]</code>".
 
- <li><p>Otherwise, <var>host</var> is a <a>domain</a> or <a>opaque host</a>, return <var>host</var>.
+ <li><p>Otherwise, <var>host</var> is a <a>domain</a>, an <a>opaque host</a>, or an <a>empty host</a>, return <var>host</var>.
 </ol>
 
 The <dfn id=concept-ipv4-serializer>IPv4 serializer</dfn> takes an

--- a/url.bs
+++ b/url.bs
@@ -254,9 +254,9 @@ point <a for=/>URLs</a> from <var>A</var> can come from untrusted sources.
 <h3 id=host-representation>Host representation</h3>
 
 <p>A <dfn export id=concept-host>host</dfn> is a <a>domain</a>, an
-<a>IPv4 address</a>, an <a>IPv6 address</a>, an <a>opaque host</a>, or an <a>empty host</a>. Typically a <a for=/>host</a>
-serves as a network address, but it is sometimes used as opaque identifier in <a for=/>URLs</a>
-where a network address is not necessary.
+<a>IPv4 address</a>, an <a>IPv6 address</a>, an <a>opaque host</a>, or an <a>empty host</a>.
+Typically a <a for=/>host</a> serves as a network address, but it is sometimes used as opaque
+identifier in <a for=/>URLs</a> where a network address is not necessary.
 
 <p class=note>The RFCs referenced in the paragraphs below are for informative purposes only. They
 have no influence on <a for=/>host</a> writing, parsing, and serialization. Unless stated otherwise
@@ -280,8 +280,8 @@ eight <dfn id=concept-ipv6-piece lt='IPv6 piece'>16-bit pieces</dfn>.
 <p class="note">Support for <code>&lt;zone_id></code> is
 <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=27234#c2">intentionally omitted</a>.
 
-<p>An <dfn export>opaque host</dfn> is a non-empty <a>ASCII string</a> holding data that can be used for
-further processing.
+<p>An <dfn export>opaque host</dfn> is a non-empty <a>ASCII string</a> holding data that can be used
+for further processing.
 
 <p class="note no-backref">An <a>opaque host</a> is only used by <a lt="is special">non-special</a>
 <a for=/>URLs</a>.
@@ -770,7 +770,8 @@ no purpose other than being a location the algorithm can jump to.
  <a>IPv6 serializer</a> on <var>host</var>,
  followed by "<code>]</code>".
 
- <li><p>Otherwise, <var>host</var> is a <a>domain</a>, an <a>opaque host</a>, or an <a>empty host</a>, return <var>host</var>.
+ <li><p>Otherwise, <var>host</var> is a <a>domain</a>, an <a>opaque host</a>, or an <a>empty
+ host</a>, return <var>host</var>.
 </ol>
 
 The <dfn id=concept-ipv4-serializer>IPv4 serializer</dfn> takes an
@@ -1174,9 +1175,10 @@ switching on <a>base URL</a>'s <a for=url>scheme</a>:
  <dd><p>a <a>path-relative-scheme-less-URL string</a>
  <dt>"<code>file</code>"
  <dd><p>a <a>scheme-relative-file-URL string</a>
- <dd><p>a <a>path-absolute-URL string</a> if <a>base URL</a>'s <a for=url>host</a> is either null or the empty string
+ <dd><p>a <a>path-absolute-URL string</a> if <a>base URL</a>'s <a for=url>host</a> is an <a>empty
+ host</a>
  <dd><p>a <a>path-absolute-non-Windows-file-URL string</a> if <a>base URL</a>'s <a for=url>host</a>
- is non-empty string
+ is not an <a>empty host</a>
  <dd><p>a <a>path-relative-scheme-less-URL string</a>
  <dt>Otherwise
  <dd><p>a <a>scheme-relative-URL string</a>
@@ -1200,7 +1202,7 @@ optionally followed by a <a>path-absolute-URL string</a>.
 "<code>//</code>", followed by an <a>opaque-host-and-port string</a>, optionally followed by a
 <a>path-absolute-URL string</a>.
 
-<p>An <dfn export>opaque-host-and-port string</dfn> must be either an empty
+<p>An <dfn export>opaque-host-and-port string</dfn> must be either the empty
 string or: a <a>valid opaque-host string</a>, optionally followed
 by "<code>:</code>" and a <a>URL-port string</a>.
 

--- a/url.bs
+++ b/url.bs
@@ -2066,10 +2066,10 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
           <a>Windows drive letter</a>, then:
 
           <ol>
-           <li><p>If <var>url</var>'s <a for=url>host</a> is non-null,
+           <li><p>If <var>url</var>'s <a for=url>host</a> is not the empty string,
            <a>validation error</a>.
 
-           <li><p>Set <var>url</var>'s <a for=url>host</a> to null and replace the second
+           <li><p>Set <var>url</var>'s <a for=url>host</a> to the empty string and replace the second
            code point in <var>buffer</var> with "<code>:</code>".
           </ol>
 

--- a/url.bs
+++ b/url.bs
@@ -1172,9 +1172,9 @@ switching on <a>base URL</a>'s <a for=url>scheme</a>:
  <dd><p>a <a>path-relative-scheme-less-URL string</a>
  <dt>"<code>file</code>"
  <dd><p>a <a>scheme-relative-file-URL string</a>
- <dd><p>a <a>path-absolute-URL string</a> if <a>base URL</a>'s <a for=url>host</a> is null
+ <dd><p>a <a>path-absolute-URL string</a> if <a>base URL</a>'s <a for=url>host</a> is either null or the empty string
  <dd><p>a <a>path-absolute-non-Windows-file-URL string</a> if <a>base URL</a>'s <a for=url>host</a>
- is non-null
+ is non-empty string
  <dd><p>a <a>path-relative-scheme-less-URL string</a>
  <dt>Otherwise
  <dd><p>a <a>scheme-relative-URL string</a>

--- a/url.bs
+++ b/url.bs
@@ -2109,11 +2109,10 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
           <a>Windows drive letter</a>, then:
 
           <ol>
-           <li><p>If <var>url</var>'s <a for=url>host</a> is not the empty string,
-           <a>validation error</a>.
+           <li><p>If <var>url</var>'s <a for=url>host</a> is neither the empty string nor null,
+           <a>validation error</a>, set <var>url</var>'s <a for=url>host</a> to the empty string.
 
-           <li><p>Set <var>url</var>'s <a for=url>host</a> to the empty string and replace the
-           second code point in <var>buffer</var> with "<code>:</code>".
+           <li><p>Replace the second code point in <var>buffer</var> with "<code>:</code>".
           </ol>
 
           <p class=note>This is a (platform-independent) Windows drive letter quirk.


### PR DESCRIPTION
Summary of changes:
1. Fixes #258
2. Introduces <b>empty host</b> term for file and non-special URL's
3. Changes definition: <b>opaque host</b> is non-empty ASCII string


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rmisev/url/empty-host-for-file.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/4bf85a0...rmisev:3893222.html)