### PR TITLE
Restrict setting protocol to "file"

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1490,6 +1490,9 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
         <p>If <var>state override</var> is given, run these subsubsteps:
 
         <ol>
+         <li><p>If <var>url</var> <a>includes credentials</a> or has a non-null <a for=url>port</a>,
+         and <var>buffer</var> is "<code>file</code>", then return.
+
          <li><p>If <var>url</var>'s <a for=url>scheme</a> is a <a>special scheme</a> and
          <var>buffer</var> is not, then return.
 

--- a/url.bs
+++ b/url.bs
@@ -1490,14 +1490,17 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
         <p>If <var>state override</var> is given, run these subsubsteps:
 
         <ol>
-         <li><p>If <var>url</var> <a>includes credentials</a> or has a non-null <a for=url>port</a>,
-         and <var>buffer</var> is "<code>file</code>", then return.
-
          <li><p>If <var>url</var>'s <a for=url>scheme</a> is a <a>special scheme</a> and
          <var>buffer</var> is not, then return.
 
          <li><p>If <var>url</var>'s <a for=url>scheme</a> is not a <a>special scheme</a> and
          <var>buffer</var> is, then return.
+
+         <li><p>If <var>url</var> <a>includes credentials</a> or has a non-null <a for=url>port</a>,
+         and <var>buffer</var> is "<code>file</code>", then return.
+
+         <li><p>If <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>" and its
+         <a for=url>host</a> is an <a>empty host</a> or null, then return.
         </ol>
 
        <li><p>Set <var>url</var>'s <a for=url>scheme</a> to <var>buffer</var>.


### PR DESCRIPTION
As file URLs cannot have username/password/port we don’t want to allow
changing the scheme of a URL that contains one or more of those
components.

Fixes #259.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://url.spec.whatwg.org/branch-snapshots/annevk/protocol-setter/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/5807b28...a8ed8d2.html)