### PR TITLE
Move some terminology to the Fetch Standard

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1112,29 +1112,6 @@ corresponding <a for=url>port</a> and is listed in the second column on the same
 <p>A <a for=/>URL</a> <dfn export>is special</dfn> if its <a for=url>scheme</a> is a
 <a>special scheme</a>.
 
-<p>A <dfn export>local scheme</dfn> is a <a for=url>scheme</a> that is "<code>about</code>",
-"<code>blob</code>", "<code>data</code>", or "<code>filesystem</code>".
-
-<p>A <a for=/>URL</a> <dfn export>is local</dfn> if its <a for=url>scheme</a> is a
-<a>local scheme</a>.
-
-<p class=note>This definition is used externally. E.g., by the Fetch Standard and
-Referrer Policy. [[FETCH]] [[REFERRER-POLICY]]
-<!-- And soonish CSP -->
-
-<p>An <dfn export id=http-scheme>HTTP(S) scheme</dfn> is a <a for=url>scheme</a> that is
-"<code>http</code>" or "<code>https</code>".
-
-<p>A <dfn export>network scheme</dfn> is a <a for=url>scheme</a> that is "<code>ftp</code>" or an
-<a>HTTP(S) scheme</a>.
-
-<p>A <dfn export>fetch scheme</dfn> is a <a for=url>scheme</a> that is "<code>about</code>",
-"<code>blob</code>", "<code>data</code>", "<code>file</code>", "<code>filesystem</code>", or a
-<a>network scheme</a>.
-
-<p class="note no-backref"><a>HTTP(S) scheme</a>, <a>network scheme</a>, and <a>fetch scheme</a> are
-used by HTML. [[HTML]]
-
 <p>A <a for=/>URL</a>
 <dfn export lt="include credentials|includes credentials">includes credentials</dfn> if its
 <a for=url>username</a> or <a for=url>password</a> is not the empty string.
@@ -3193,6 +3170,7 @@ Chris Rebert,
 Corey Farwell,
 Dan Appelquist,
 Daniel Bratell,
+Daniel Stenberg,
 David Burns,
 David Håsäther,
 David Sheets,


### PR DESCRIPTION
This wasn’t used by the URL Standard directly so might as well go to
Fetch.

Change to Fetch: https://github.com/whatwg/fetch/issues/512.

Fixes #241.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://url.spec.whatwg.org/branch-snapshots/annevk/url-terminology/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/7286569...2d8b4d7.html)