### PR TITLE
IPv4 in IPv6 cleanup

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -623,10 +623,10 @@ then runs these steps:
           <p>Otherwise, set <var>ipv4Piece</var> to <var>ipv4Piece</var> &times; 10 +
           <var>number</var>.
 
-         <li><p>Increase <var>pointer</var> by one.
-
          <li><p>If <var>ipv4Piece</var> is greater than 255, <a>validation error</a>, return
          failure.
+
+         <li><p>Increase <var>pointer</var> by one.
         </ol>
 
        <li><p>Set <var>piece</var> to <var>piece</var> &times; 0x100 + <var>ipv4Piece</var>.
@@ -634,10 +634,9 @@ then runs these steps:
        <li><p>Increase <var>numbersSeen</var> by one.
 
        <li><p>If <var>numbersSeen</var> is 2 or 4, then increase <var>piece pointer</var> by one.
-
-       <li><p>If <a>c</a> is the <a>EOF code point</a> and <var>numbersSeen</var> is not 4,
-       <a>validation error</a>, return failure.
       </ol>
+
+     <li><p>If <var>numbersSeen</var> is not 4, <a>validation error</a>, return failure.
 
      <li><p><a for=iteration>Break</a>.
     </ol>


### PR DESCRIPTION
Changes:

1. Moves _ipv4Piece_ verification step right after the _ipv4Piece_ calculation. Because if the "_ipv4Piece_ > 255" verification returns failure, then no need to increase _pointer_.

2. Moves the last (8.) step to the outside of 6.5.5 loop. This lets drop `c is the EOF` check in this moved step, because loop stops on `EOF`. This obviously gives a better performance.

These changes are based on https://github.com/nodejs/node/pull/12315#discussion_r110858300 and https://github.com/nodejs/node/pull/12315#discussion_r110879264


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rmisev/url/ipv4-in-ipv6-cleanup.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/703fcd0...rmisev:a1e1e80.html)