### PR TITLE
Fix windows drive letter handling in the file state

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1840,11 +1840,11 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
           <p>If at least one of the following is true
 
           <ul class=brief>
+           <li><p><a>remaining</a> consists of zero code points
            <li><p><a>c</a> and the first code point of <a>remaining</a> are not a
            <a>Windows drive letter</a>
-           <li><p><a>remaining</a> consists of one code point
-           <li><p><a>remaining</a>'s second code point is <em>not</em> U+002F (/), U+005C (\),
-           U+003F (?), or U+0023 (#)
+           <li><p><a>remaining</a> has at least 2 code points and <a>remaining</a>'s second code
+           point is <em>not</em> U+002F (/), U+005C (\), U+003F (?), or U+0023 (#)
           </ul>
 
           <p>then set <var>url</var>'s <a for=url>host</a> to <var>base</var>'s <a for=url>host</a>,


### PR DESCRIPTION
Fixes #304


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rmisev/url/file-state-304.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/488c459...rmisev:d671fd9.html)