### PR TITLE
Make URL's origin return solely ASCII code points

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2665,11 +2665,8 @@ url.pathname // "/%F0%9F%8F%B3%EF%B8%8F%E2%80%8D%F0%9F%8C%88"</code></pre>
 </ol>
 
 <p>The <dfn attribute for=URL><code>origin</code></dfn> attribute's getter must return the
-<a lt="Unicode serialization of an origin">Unicode serialization</a> of <a>context object</a>'s
-<a for=URL>url</a>'s <a for=url>origin</a>. [[!HTML]]
-
-<p class="note no-backref">It returns the Unicode rather than the ASCII serialization for
-compatibility with HTML's <code>MessageEvent</code> feature. [[!HTML]]
+<a lt="serialization of an origin">serialization</a> of <a>context object</a>'s <a for=URL>url</a>'s
+<a for=url>origin</a>. [[!HTML]]
 
 <p>The <dfn attribute for=URL><code>protocol</code></dfn> attribute's getter must return
 <a>context object</a> <a for=URL>url</a>'s <a for=url>scheme</a>, followed by U+003A (:).


### PR DESCRIPTION
See https://github.com/whatwg/html/issues/2568 for discussion.

See https://github.com/whatwg/html/pull/2689 for the corresponding
change to the HTML Standard.

Closes #297.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://url.spec.whatwg.org/branch-snapshots/annevk/ascii-origin/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/fe6b251...0098115.html)