### PR TITLE
Specify window.webkitURL as an alias to URL

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2532,7 +2532,8 @@ takes a string <var>input</var>, <a>UTF-8 encodes</a> it, and then returns the r
 
 <pre class=idl>
 [Constructor(USVString url, optional USVString base),
- Exposed=(Window,Worker)]
+ Exposed=(Window,Worker),
+ LegacyWindowAlias=webkitURL]
 interface URL {
   stringifier attribute USVString href;
   readonly attribute USVString origin;


### PR DESCRIPTION
Fixes #135.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://url.spec.whatwg.org/branch-snapshots/zcorpan/webkiturl/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/20c3257...62a0abf.html)