### PR TITLE
Normalize port after updating scheme

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1400,6 +1400,9 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
 
        <li><p>Set <var>url</var>'s <a for=url>scheme</a> to <var>buffer</var>.
 
+       <li><p>If <var>url</var>'s <a for=url>port</a> is <var>url</var>'s <a for=url>scheme</a>'s
+       <a>default port</a>, then set <var>url</var>'s <a for=url>port</a> to null.
+
        <li><p>Set <var>buffer</var> to the empty string.
 
        <li><p>If <var>state override</var> is given, then return.

--- a/url.bs
+++ b/url.bs
@@ -1400,12 +1400,17 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
 
        <li><p>Set <var>url</var>'s <a for=url>scheme</a> to <var>buffer</var>.
 
-       <li><p>If <var>url</var>'s <a for=url>port</a> is <var>url</var>'s <a for=url>scheme</a>'s
-       <a>default port</a>, then set <var>url</var>'s <a for=url>port</a> to null.
+       <li>
+         <p>If <var>state override</var> is given, then:
+
+         <ol>
+          <li><p>If <var>url</var>'s <a for=url>port</a> is <var>url</var>'s <a for=url>scheme</a>'s
+          <a>default port</a>, then set <var>url</var>'s <a for=url>port</a> to null.
+
+          <li><p>Return.
+         </ol>
 
        <li><p>Set <var>buffer</var> to the empty string.
-
-       <li><p>If <var>state override</var> is given, then return.
 
        <li>
         <p>If <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>", then:


### PR DESCRIPTION
Closes #327.

Tests: https://github.com/w3c/web-platform-tests/pull/6346


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/TimothyGu/url/scheme-port.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/b128ba9...TimothyGu:156b207.html)