### PR TITLE
Fix Windows drive letter handling in the file slash state

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1068,21 +1068,22 @@ code point is U+003A (:).
 <p class="note">As per the <a href=#url-writing>URL writing</a> section, only a
 <a>normalized Windows drive letter</a> is conforming.
 
-<p>A string <dfn>starts with Windows drive letter</dfn> if all of the following are true:
+<p>A string
+<dfn lt="start with a Windows drive letter|starts with a Windows drive letter">starts with a Windows drive letter</dfn>
+if all of the following are true:
 
-<ul>
- <li><p>it contains at least two code points and the first two code points are
- <a>Windows drive letter</a>.
-
- <li><p>it contains two code points or the third code point is U+002F (/), U+005C (\), U+003F (?),
- or U+0023 (#).
+<ul class=brief>
+ <li>its <a for=string>length</a> is greater than or equal to 2
+ <li>its first two code points are a <a>Windows drive letter</a>
+ <li>its <a for=string>length</a> is 2 or the third code point is U+002F (/), U+005C (\),
+ U+003F (?), or U+0023 (#).
 </ul>
 
-<div class=example id=example-starts-with-widows-drive-letter>
+<div class=example id=example-start-with-a-widows-drive-letter>
  <table>
   <tr>
    <th>String
-   <th>Result
+   <th>Starts with a Windows drive letter
   <tr>
    <td>"<code>c:</code>"
    <td>✅
@@ -1861,11 +1862,11 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
        <dd>
         <ol>
          <li>
-          <p>If the substring from <var>pointer</var> in the <var>input</var> does not
-          <a lt="starts with Windows drive letter">start with Windows drive letter</a>,
-          then set <var>url</var>'s <a for=url>host</a> to <var>base</var>'s <a for=url>host</a>,
-          <var>url</var>'s <a for=url>path</a> to a copy of <var>base</var>'s <a for=url>path</a>,
-          and then <a>shorten</a> <var>url</var>'s <a for=url>path</a>.
+          <p>If the substring from <var>pointer</var> in <var>input</var> does not
+          <a>start with a Windows drive letter</a>, then set <var>url</var>'s <a for=url>host</a> to
+          <var>base</var>'s <a for=url>host</a>, <var>url</var>'s <a for=url>path</a> to a copy of
+          <var>base</var>'s <a for=url>path</a>, and then <a>shorten</a> <var>url</var>'s
+          <a for=url>path</a>.
 
           <p class=note>This is a (platform-independent) Windows drive letter quirk.
 
@@ -1896,9 +1897,9 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
 
       <ol>
        <li>
-        <p>If <var>base</var> is non-null and <var>base</var>'s <a for=url>scheme</a> is
-        "<code>file</code>" and the substring from <var>pointer</var> in the <var>input</var> does
-        not <a lt="starts with Windows drive letter">start with Windows drive letter</a>, then:
+        <p>If <var>base</var> is non-null, <var>base</var>'s <a for=url>scheme</a> is
+        "<code>file</code>", and the substring from <var>pointer</var> in <var>input</var> does not
+        <a>start with a Windows drive letter</a>, then:
 
         <ol>
          <li>

--- a/url.bs
+++ b/url.bs
@@ -1068,6 +1068,33 @@ code point is U+003A (:).
 <p class="note">As per the <a href=#url-writing>URL writing</a> section, only a
 <a>normalized Windows drive letter</a> is conforming.
 
+<p>A string <dfn>starts with Windows drive letter</dfn> if all of the following are true:
+
+<ul>
+ <li><p>it contains at least two code points and the first two code points are
+ <a>Windows drive letter</a>.
+
+ <li><p>it contains two code points or the third code point is U+002F (/), U+005C (\), U+003F (?),
+ or U+0023 (#).
+</ul>
+
+<div class=example id=example-starts-with-widows-drive-letter>
+ <table>
+  <tr>
+   <th>String
+   <th>Result
+  <tr>
+   <td>"<code>c:</code>"
+   <td>✅
+  <tr>
+   <td>"<code>c:/</code>"
+   <td>✅
+  <tr>
+   <td>"<code>c:a</code>"
+   <td>❌
+ </table>
+</div>
+
 <p id=pop-a-urls-path>To <dfn local-lt=shorten>shorten a <var>url</var>'s path</dfn>:
 
 <ol>

--- a/url.bs
+++ b/url.bs
@@ -1897,7 +1897,8 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
       <ol>
        <li>
         <p>If <var>base</var> is non-null and <var>base</var>'s <a for=url>scheme</a> is
-        "<code>file</code>", then:
+        "<code>file</code>" and the substring from <var>pointer</var> in the <var>input</var> does
+        not <a lt="starts with Windows drive letter">start with Windows drive letter</a>, then:
 
         <ol>
          <li>

--- a/url.bs
+++ b/url.bs
@@ -1075,7 +1075,7 @@ if all of the following are true:
 <ul class=brief>
  <li>its <a for=string>length</a> is greater than or equal to 2
  <li>its first two code points are a <a>Windows drive letter</a>
- <li>its <a for=string>length</a> is 2 or the third code point is U+002F (/), U+005C (\),
+ <li>its <a for=string>length</a> is 2 or its third code point is U+002F (/), U+005C (\),
  U+003F (?), or U+0023 (#).
 </ul>
 

--- a/url.bs
+++ b/url.bs
@@ -1861,17 +1861,9 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
        <dd>
         <ol>
          <li>
-          <p>If at least one of the following is true
-
-          <ul class=brief>
-           <li><p><a>remaining</a> consists of zero code points
-           <li><p><a>c</a> and the first code point of <a>remaining</a> are not a
-           <a>Windows drive letter</a>
-           <li><p><a>remaining</a> has at least 2 code points and <a>remaining</a>'s second code
-           point is <em>not</em> U+002F (/), U+005C (\), U+003F (?), or U+0023 (#)
-          </ul>
-
-          <p>then set <var>url</var>'s <a for=url>host</a> to <var>base</var>'s <a for=url>host</a>,
+          <p>If the substring from <var>pointer</var> in the <var>input</var> does not
+          <a lt="starts with Windows drive letter">start with Windows drive letter</a>,
+          then set <var>url</var>'s <a for=url>host</a> to <var>base</var>'s <a for=url>host</a>,
           <var>url</var>'s <a for=url>path</a> to a copy of <var>base</var>'s <a for=url>path</a>,
           and then <a>shorten</a> <var>url</var>'s <a for=url>path</a>.
 


### PR DESCRIPTION
1. Introduces term: "a string starts with Windows drive letter". It simplifies the ***file state*** and solves the **remaining** problem (https://github.com/whatwg/url/issues/308).
2. Fixes https://github.com/whatwg/url/issues/303.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rmisev/url/file-slash-state-fix.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/19e0ffa...rmisev:32aa25e.html)