### PR TITLE
Percent-encode additional characters in "fragment state".

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -170,7 +170,7 @@ contains bytes that are not <a>ASCII bytes</a> might be insecure and is not reco
 and all <a>code points</a> greater than U+007E (~).
 
 <p>The <dfn>fragment percent-encode set</dfn> is the <a>C0 control percent-encode set</a> and
-U+0020 SPACE, U+0022 ("), U+003C(&lt;), U+003E (&gt;), and U+0060 (`).
+U+0020 SPACE, U+0022 ("), U+003C (&lt;), U+003E (&gt;), and U+0060 (`).
 
 <p>The <dfn oldids=default-encode-set>path percent-encode set</dfn> is the
 <a>fragment percent-encode set</a> and U+0023 (#), U+003F (?), U+007B ({), and U+007D (}).

--- a/url.bs
+++ b/url.bs
@@ -169,16 +169,15 @@ contains bytes that are not <a>ASCII bytes</a> might be insecure and is not reco
 <p>The <dfn oldids=simple-encode-set>C0 control percent-encode set</dfn> are the <a>C0 controls</a>
 and all <a>code points</a> greater than U+007E (~).
 
+<p>The <dfn>fragment percent-encode set</dfn> is the <a>C0 control percent-encode set</a> and
+U+0022 SPACE, U+0022 ("), U+003C(&lt;), U+003E (&gt;), and U+0060 (`).
+
 <p>The <dfn oldids=default-encode-set>path percent-encode set</dfn> is the
-<a>C0 control percent-encode set</a> and U+0020 SPACE, U+0022 ("), U+0023 (#), U+003C (&lt;),
-U+003E (>), U+003F (?), U+0060 (`), U+007B ({), and U+007D (}).
+<a>fragment percent-encode set</a> and U+0023 (#), U+003F (?), U+007B ({), and U+007D (}).
 
 <p>The <dfn oldids=userinfo-encode-set>userinfo percent-encode set</dfn> is the
 <a>path percent-encode set</a> and U+002F (/), U+003A (:), U+003B (;), U+003D (=), U+0040 (@),
 U+005B ([), U+005C (\), U+005D (]), U+005E (^), and U+007C (|).
-
-<p>The <dfn>fragment percent-encode set</dfn> is the <a>C0 control percent-encode set</a> and
-U+0022 ("), U+003C(<), U+003E (>), and U+0060 (`).
 
 <p>To <dfn>UTF-8 percent encode</dfn> a <var>codePoint</var>, using a <var>percentEncodeSet</var>,
 run these steps:

--- a/url.bs
+++ b/url.bs
@@ -170,7 +170,7 @@ contains bytes that are not <a>ASCII bytes</a> might be insecure and is not reco
 and all <a>code points</a> greater than U+007E (~).
 
 <p>The <dfn>fragment percent-encode set</dfn> is the <a>C0 control percent-encode set</a> and
-U+0022 SPACE, U+0022 ("), U+003C(&lt;), U+003E (&gt;), and U+0060 (`).
+U+0020 SPACE, U+0022 ("), U+003C(&lt;), U+003E (&gt;), and U+0060 (`).
 
 <p>The <dfn oldids=default-encode-set>path percent-encode set</dfn> is the
 <a>fragment percent-encode set</a> and U+0023 (#), U+003F (?), U+007B ({), and U+007D (}).

--- a/url.bs
+++ b/url.bs
@@ -177,6 +177,9 @@ U+003E (>), U+003F (?), U+0060 (`), U+007B ({), and U+007D (}).
 <a>path percent-encode set</a> and U+002F (/), U+003A (:), U+003B (;), U+003D (=), U+0040 (@),
 U+005B ([), U+005C (\), U+005D (]), U+005E (^), and U+007C (|).
 
+<p>The <dfn>fragment percent-encode set</dfn> is the <a>C0 control percent-encode set</a> and
+U+0022 ("), U+003C(<), U+003E (>), and U+0060 (`).
+
 <p>To <dfn>UTF-8 percent encode</dfn> a <var>codePoint</var>, using a <var>percentEncodeSet</var>,
 run these steps:
 
@@ -2161,7 +2164,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
        <li><p>If <a>c</a> is U+0025 (%) and <a>remaining</a> does not start with two
        <a>ASCII hex digits</a>, <a>validation error</a>.
 
-       <li><p><a>UTF-8 percent encode</a> <a>c</a> using the <a>C0 control percent-encode set</a>
+       <li><p><a>UTF-8 percent encode</a> <a>c</a> using the <a>fragment percent-encode set</a>
        and append the result to <var>url</var>'s <a for=url>fragment</a>.
       </ol>
     </dl>


### PR DESCRIPTION
Currently, we percent-encode characters in "fragment state" using the C0
control percent-encode set. Firefox encodes more than that, and it seems
reasonable to align around that behavior for reasons spelled out in #291
and the comments of #344.

This patch adds a new "fragment percent-encode set" which contains the
C0 control percent-encode set, along with:

* 0x22 (")
* 0x3C (<)
* 0x3E (>)
* 0x60 (`)

Closes #344.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/mikewest/url/fragment-percent-encode.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/url/20c3257...mikewest:6c80db9.html)