### PR TITLE
Remove Googlefight links

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -37,7 +37,7 @@ Boilerplate: omit feedback-header, omit conformance
  <li><p>Standardize on the term URL. URI and IRI are just confusing. In
  practice a single algorithm is used for both so keeping them distinct is
  not helping anyone. URL also easily wins the
- <a href="http://www.googlefight.com/index.php?word1=url&amp;word2=uri">search result popularity contest</a>.
+ <a href="https://trends.google.com/trends/explore?q=url,uri">search result popularity contest</a>.
 
  <li><p>Supplanting <a href="https://tools.ietf.org/html/rfc6454#section-4">Origin of a URI [sic]</a>.
  [[RFC6454]]
@@ -3157,6 +3157,7 @@ Michel Suignard,
 Noah Levitt,
 Peter Occil,
 Philip Jägenstedt,
+Philippe Ombredanne,
 Prayag Verma,
 Rimas Misevičius,
 Robert Kieffer,


### PR DESCRIPTION
The web site does not work anymore.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://s3.amazonaws.com/pr-preview/pombredanne/url-1/pull/352.html" title="Last updated on Nov 27, 2017, 2:26 PM GMT">Preview</a> | <a href="https://s3.amazonaws.com/pr-preview/whatwg/url/3b6b0b4...pombredanne:8746419.html" title="Last updated on Nov 27, 2017, 2:26 PM GMT">Diff</a>