### PR TITLE
Meta: adopt more whatwg/meta guidelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
     - ENCRYPTION_LABEL="82f6fcb5a224"
 
 script:
-  - curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh && bash ./deploy.sh
+  - make deploy
 
 branches:
   only:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please see the [contributor guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see the [contributor guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md).
+Please see the [WHATWG Contributor Guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md).

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ local: url.bs
 
 remote: url.bs
 	curl https://api.csswg.org/bikeshed/ -f -F file=@url.bs > url.html -F md-Text-Macro="SNAPSHOT-LINK LOCAL COPY"
+
+deploy: dom.bs
+	curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh && bash ./deploy.sh

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,5 @@ local: url.bs
 remote: url.bs
 	curl https://api.csswg.org/bikeshed/ -f -F file=@url.bs > url.html -F md-Text-Macro="SNAPSHOT-LINK LOCAL COPY"
 
-deploy: dom.bs
+deploy: url.bs
 	curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh && bash ./deploy.sh

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you want to do a complete "local deploy" including commit and/or branch snaps
 ### Merge policy
 
 If you can commit to this repository, see the
-[maintainer guidelines](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md).
+[WHATWG Maintainer Guidelines](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md).
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -27,15 +27,12 @@ If you want to preview the spec locally, you can either use a locally installed 
 running `make remote`.
 
 If you want to do a complete "local deploy" including commit and/or branch snapshots, run
-
-```
-./deploy.sh --local
-```
+`make deploy`.
 
 ### Merge policy
 
 If you can commit to this repository, see the
-[html repository's TEAM](https://github.com/whatwg/html/blob/master/TEAM.md) for guidelines.
+[maintainer guidelines](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md).
 
 ### Tests
 


### PR DESCRIPTION
In particular:

* Add a CONTRIBUTING.md resource that points to the generic one.
* Adjust the Makefile and README to account for the shared deploy script.
* Make the README point to the shared maintainer guidelines.