### PR TITLE
Editorial: fix port value in the origin's example

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2306,7 +2306,7 @@ background information. [[!HTML]]
 
   <p class="example no-backref" id=example-43b5cea5>The <a for=url>origin</a> of
   <code>blob:https://whatwg.org/d0360e2f-caee-469f-9a2f-87d5b0456f6f</code> is the tuple
-  (<code>https</code>, <code>whatwg.org</code>, <code>443</code>, null).
+  (<code>https</code>, <code>whatwg.org</code>, null, null).
 
  <dt>"<code>ftp</code>"
  <dt>"<code>gopher</code>"


### PR DESCRIPTION
The URLs port in the tuple origin must be null, because port is not
specified in the input:
`blob:https://whatwg.org/d0360e2f-caee-469f-9a2f-87d5b0456f6f`

According to specification, if port is not specified or is default for
scheme, then URLs port is set to null:
https://url.spec.whatwg.org/#concept-url-port
https://url.spec.whatwg.org/#ref-for-default-port%E2%91%A0


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/366.html" title="Last updated on Jan 9, 2018, 2:31 PM GMT (35d6bd5)">Preview</a> | <a href="https://whatpr.org/url/366/0d15b3f...35d6bd5.html" title="Last updated on Jan 9, 2018, 2:31 PM GMT (35d6bd5)">Diff</a>