### PR TITLE
Use definitions in FileAPI spec to resolve blob URLs and their origins.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1120,8 +1120,9 @@ resource the <a for=/>URL</a>'s other components identify. It is initially null.
 <p id=non-relative-flag>A <a for=/>URL</a> also has an associated
 <dfn export for=url>cannot-be-a-base-URL flag</dfn>. It is initially unset.
 
-<p>A <a for=/>URL</a> also has an associated <dfn export for=url id=concept-url-blob-entry>blob URL entry</dfn>
-that is either null or a <a for=/>blob URL entry</a>. It is initially null.
+<p>A <a for=/>URL</a> also has an associated
+<dfn export for=url id=concept-url-blob-entry>blob URL entry</dfn> that is either null or a
+<a for=/>blob URL entry</a>. It is initially null.
 
 <p class="note no-backref">This is used to support caching the object a "<code>blob</code>" URL
 refers to as well as its origin. It is important that these are cached as the <a for=/>URL</a> might
@@ -1428,8 +1429,8 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
  "<code>blob</code>", return <var>url</var>.
 
  <li><p>Set <var>url</var>'s <a for=url>blob URL entry</a> to the result of
- <a for="blob URL" lt="resolve">resolving the blob URL</a> <var>url</var>,
- if that did not return failure, and null otherwise.
+ <a for="blob URL" lt="resolve">resolving the blob URL</a> <var>url</var>, if that did not return
+ failure, and null otherwise.
 
  <li><p>Return <var>url</var>.
 </ol>
@@ -2432,16 +2433,18 @@ background information. [[!HTML]]
 <dl class=switch>
  <dt>"<code>blob</code>"
  <dd>
-  <p>If <a for=/>URL</a>'s <a for=url>blob URL entry</a> is not null, return <a for=/>URL</a>'s
-  <a for=url>blob URL entry</a>'s <a for="blob URL entry">environment</a>'s
-  <a for="environment settings object">origin</a>.
+  <ol>
+   <li><p>If <a for=/>URL</a>'s <a for=url>blob URL entry</a> is non-null, then return
+   <a for=/>URL</a>'s <a for=url>blob URL entry</a>'s <a for="blob URL entry">environment</a>'s
+   <a for="environment settings object">origin</a>.
 
-  <p>Let <var>url</var> be the result of <a lt="basic URL parser">parsing</a> <a for=/>URL</a>'s
-  <a for=url>path</a>[0].
+   <li><p>Let <var>url</var> be the result of <a lt="basic URL parser">parsing</a>
+   <a for=/>URL</a>'s <a for=url>path</a>[0].
 
-  <p>Return a new <a>opaque origin</a>, if <var>url</var> is failure, and <var>url</var>'s
-  <a for=url>origin</a> otherwise.
-  <!-- Did you mean: recursion -->
+   <li><p>Return a new <a>opaque origin</a>, if <var>url</var> is failure, and <var>url</var>'s
+   <a for=url>origin</a> otherwise.
+   <!-- Did you mean: recursion -->
+  </ol>
 
   <p class="example no-backref" id=example-43b5cea5>The <a for=url>origin</a> of
   <code>blob:https://whatwg.org/d0360e2f-caee-469f-9a2f-87d5b0456f6f</code> is the tuple

--- a/url.bs
+++ b/url.bs
@@ -1129,6 +1129,12 @@ that is null, a {{Blob}} object, or a {{MediaSource}} object. It is initially nu
 "<code>blob</code>" <a for=/>URLs</a>, but others can be added going forward, hence
 "object".
 
+<p>A <a for=/>URL</a> also has an associated
+<dfn for=url>cached origin</dfn> that is either null or a <a>ASCII string</a>.
+It is initially null.
+
+<p class="note">This is used to support caching the origin of a "<code>blob</code>"
+<a for=/>URL</a> at the time it is parsed.
 
 <h3 id=url-miscellaneous>URL miscellaneous</h3>
 
@@ -1429,12 +1435,11 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
  <li><p>If <var>url</var>'s <a for=url>scheme</a> is not
  "<code>blob</code>", return <var>url</var>.
 
- <li><p>If <var>url</var>'s <a for=url>path</a> <a for=list>is empty</a> or <var>url</var>'s
- <a for=url>path</a>[0] is not in the <a>Blob URL Store</a>, then return <var>url</var>.
- [[!FILEAPI]]
+ <li><p>Set <var>url</var>'s <a for=url>cached origin</a> to the result of
+ <a for="blob URL" lt="resolve the origin">resolving the origin of the blob URL</a> <var>url</var>.
 
- <li><p>Set <var>url</var>'s <a for=url>object</a> to the entry in the <a>Blob URL Store</a>
- corresponding to <var>url</var>'s <a for=url>path</a>[0].
+ <li><p>Set <var>url</var>'s <a for=url>object</a> to the result of
+ <a for="blob URL" lt="resolve">resolving the blob URL</a> <var>url</var>.
 
  <li><p>Return <var>url</var>.
 </ol>
@@ -2437,11 +2442,10 @@ background information. [[!HTML]]
 <dl class=switch>
  <dt>"<code>blob</code>"
  <dd>
-  <p>Let <var>url</var> be the result of <a lt="basic URL parser">parsing</a> <a for=/>URL</a>'s
-  <a for=url>path</a>[0].
+  If <a for=/>URL</a>'s <a for=url>cached origin</a> is not null, return
+  <a for=/>URL</a>'s <a for=url>cached origin</a>.
 
-  <p>Return a new <a>opaque origin</a>, if <var>url</var> is failure, and <var>url</var>'s
-  <a for=url>origin</a> otherwise.
+  <p>Return the result of <a for="blob URL" lt="resolve the origin">resolving the origin of the blob URL</a>.
   <!-- Did you mean: recursion -->
 
   <p class="example no-backref" id=example-43b5cea5>The <a for=url>origin</a> of

--- a/url.bs
+++ b/url.bs
@@ -1120,8 +1120,8 @@ resource the <a for=/>URL</a>'s other components identify. It is initially null.
 <p id=non-relative-flag>A <a for=/>URL</a> also has an associated
 <dfn export for=url>cannot-be-a-base-URL flag</dfn>. It is initially unset.
 
-<p>A <a for=/>URL</a> also has an associated <dfn export for=url id=concept-url-blob-entry>blob entry</dfn>
-that is either null or a <a>blob URL entry</a>. It is initially null.
+<p>A <a for=/>URL</a> also has an associated <dfn export for=url id=concept-url-blob-entry>blob URL entry</dfn>
+that is either null or a <a for=/>blob URL entry</a>. It is initially null.
 
 <p class="note no-backref">This is used to support caching the object a "<code>blob</code>" URL
 refers to as well as its origin. It is important that these are cached as the <a for=/>URL</a> might
@@ -1427,7 +1427,7 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
  <li><p>If <var>url</var>'s <a for=url>scheme</a> is not
  "<code>blob</code>", return <var>url</var>.
 
- <li><p>Set <var>url</var>'s <a for=url>blob entry</a> to the result of
+ <li><p>Set <var>url</var>'s <a for=url>blob URL entry</a> to the result of
  <a for="blob URL" lt="resolve">resolving the blob URL</a> <var>url</var>,
  if that did not return failure, and null otherwise.
 
@@ -2432,8 +2432,8 @@ background information. [[!HTML]]
 <dl class=switch>
  <dt>"<code>blob</code>"
  <dd>
-  <p>If <a for=/>URL</a>'s <a for=url>blob entry</a> is not null, return <a for=/>URL</a>'s
-  <a for=url>blob entry</a>'s <a for="blob URL entry">environment</a>'s
+  <p>If <a for=/>URL</a>'s <a for=url>blob URL entry</a> is not null, return <a for=/>URL</a>'s
+  <a for=url>blob URL entry</a>'s <a for="blob URL entry">environment</a>'s
   <a for="environment settings object">origin</a>.
 
   <p>Let <var>url</var> be the result of <a lt="basic URL parser">parsing</a> <a for=/>URL</a>'s

--- a/url.bs
+++ b/url.bs
@@ -1120,24 +1120,13 @@ resource the <a for=/>URL</a>'s other components identify. It is initially null.
 <p id=non-relative-flag>A <a for=/>URL</a> also has an associated
 <dfn export for=url>cannot-be-a-base-URL flag</dfn>. It is initially unset.
 
-<p>A <a for=/>URL</a> also has an associated <dfn export for=url id=concept-url-object>object</dfn>
-that is null, a {{Blob}} object, or a {{MediaSource}} object. It is initially null.
-[[!FILEAPI]]
-[[!MEDIA-SOURCE]]
+<p>A <a for=/>URL</a> also has an associated <dfn export for=url id=concept-url-blob-entry>blob entry</dfn>
+that is either null or a <a>blob URL entry</a>. It is initially null.
 
-<p class="note no-backref">At this point this is used primarily to support
-"<code>blob</code>" <a for=/>URLs</a>, but others can be added going forward, hence
-"object".
-
-<p>A <a for=/>URL</a> also has an associated
-<dfn for=url>object origin</dfn> that is either null or an <a for=/>origin</a>.
-It is initially null.
-
-<p class="note">This is used to support caching the origin of a "<code>blob</code>"
-<a for=/>URL</a> at the time it is parsed. It is important that both the
-<a for=url>object</a> and <a for=url>object origin</a> are cached as the <a for=/>URL</a>
-might be removed from the <a>blob URL store</a> between parsing and fetching, but
-fetching will still need to succeed.
+<p class="not no-backref">This is used to support caching the object a "<code>blob</code>" URL
+refers to as well as its origin. It is important that these are cached as the <a for=/>URL</a> might
+be removed from the <a>blob URL store</a> between parsing and fetching, while fetching will still
+need to succeed.
 
 <h3 id=url-miscellaneous>URL miscellaneous</h3>
 
@@ -1438,13 +1427,9 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
  <li><p>If <var>url</var>'s <a for=url>scheme</a> is not
  "<code>blob</code>", return <var>url</var>.
 
- <li><p>Set <var>url</var>'s <a for=url>object</a> to the result of
+ <li><p>Set <var>url</var>'s <a for=url>blob entry</a> to the result of
  <a for="blob URL" lt="resolve">resolving the blob URL</a> <var>url</var>,
  or null if that returned failure.
-
- <li><p>If <var>url</var>'s <a for=url>object</a> is not null,
- set <var>url</var>'s <a for=url>object origin</a> to the result of
- <a for="blob URL" lt="resolve the origin">resolving the origin of the blob URL</a> <var>url</var>.
 
  <li><p>Return <var>url</var>.
 </ol>
@@ -2447,10 +2432,16 @@ background information. [[!HTML]]
 <dl class=switch>
  <dt>"<code>blob</code>"
  <dd>
-  If <a for=/>URL</a>'s <a for=url>object origin</a> is not null, return
-  <a for=/>URL</a>'s <a for=url>object origin</a>.
+  If <a for=/>URL</a>'s <a for=url>blob entry</a> is not null, return <a for=/>URL</a>'s
+  <a for=url>blob entry</a>'s <a for="blob URL entry">environment</a>'s
+  <a for="environment settings object">origin</a>.
 
-  <p>Return the result of <a for="blob URL" lt="resolve the origin">resolving the origin of the blob URL</a>.
+  <p>Let <var>url</var> be the result of <a lt="basic URL parser">parsing</a> <a for=/>URL</a>'s
+  <a for=url>path</a>[0].
+
+  <p>Return a new <a>opaque origin</a>, if <var>url</var> is failure, and <var>url</var>'s
+  <a for=url>origin</a> otherwise.
+
   <!-- Did you mean: recursion -->
 
   <p class="example no-backref" id=example-43b5cea5>The <a for=url>origin</a> of

--- a/url.bs
+++ b/url.bs
@@ -1429,7 +1429,7 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
 
  <li><p>Set <var>url</var>'s <a for=url>blob entry</a> to the result of
  <a for="blob URL" lt="resolve">resolving the blob URL</a> <var>url</var>,
- or null if that returned failure.
+ if that did not return failure, and null otherwise.
 
  <li><p>Return <var>url</var>.
 </ol>
@@ -2441,7 +2441,6 @@ background information. [[!HTML]]
 
   <p>Return a new <a>opaque origin</a>, if <var>url</var> is failure, and <var>url</var>'s
   <a for=url>origin</a> otherwise.
-
   <!-- Did you mean: recursion -->
 
   <p class="example no-backref" id=example-43b5cea5>The <a for=url>origin</a> of

--- a/url.bs
+++ b/url.bs
@@ -1123,7 +1123,7 @@ resource the <a for=/>URL</a>'s other components identify. It is initially null.
 <p>A <a for=/>URL</a> also has an associated <dfn export for=url id=concept-url-blob-entry>blob entry</dfn>
 that is either null or a <a>blob URL entry</a>. It is initially null.
 
-<p class="not no-backref">This is used to support caching the object a "<code>blob</code>" URL
+<p class="note no-backref">This is used to support caching the object a "<code>blob</code>" URL
 refers to as well as its origin. It is important that these are cached as the <a for=/>URL</a> might
 be removed from the <a>blob URL store</a> between parsing and fetching, while fetching will still
 need to succeed.
@@ -2432,7 +2432,7 @@ background information. [[!HTML]]
 <dl class=switch>
  <dt>"<code>blob</code>"
  <dd>
-  If <a for=/>URL</a>'s <a for=url>blob entry</a> is not null, return <a for=/>URL</a>'s
+  <p>If <a for=/>URL</a>'s <a for=url>blob entry</a> is not null, return <a for=/>URL</a>'s
   <a for=url>blob entry</a>'s <a for="blob URL entry">environment</a>'s
   <a for="environment settings object">origin</a>.
 

--- a/url.bs
+++ b/url.bs
@@ -1130,11 +1130,14 @@ that is null, a {{Blob}} object, or a {{MediaSource}} object. It is initially nu
 "object".
 
 <p>A <a for=/>URL</a> also has an associated
-<dfn for=url>object origin</dfn> that is either null or an <a>ASCII string</a>.
+<dfn for=url>object origin</dfn> that is either null or an <a for=/>origin</a>.
 It is initially null.
 
 <p class="note">This is used to support caching the origin of a "<code>blob</code>"
-<a for=/>URL</a> at the time it is parsed.
+<a for=/>URL</a> at the time it is parsed. It is important that both the
+<a for=url>object</a> and <a for=url>object origin</a> are cached as the <a for=/>URL</a>
+might be removed from the <a>blob URL store</a> between parsing and fetching, but
+fetching will still need to succeed.
 
 <h3 id=url-miscellaneous>URL miscellaneous</h3>
 
@@ -1435,12 +1438,13 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
  <li><p>If <var>url</var>'s <a for=url>scheme</a> is not
  "<code>blob</code>", return <var>url</var>.
 
- <li><p>Set <var>url</var>'s <a for=url>object origin</a> to the result of
- <a for="blob URL" lt="resolve the origin">resolving the origin of the blob URL</a> <var>url</var>.
-
  <li><p>Set <var>url</var>'s <a for=url>object</a> to the result of
  <a for="blob URL" lt="resolve">resolving the blob URL</a> <var>url</var>,
  or null if that returned failure.
+
+ <li><p>If <var>url</var>'s <a for=url>object</a> is not null,
+ set <var>url</var>'s <a for=url>object origin</a> to the result of
+ <a for="blob URL" lt="resolve the origin">resolving the origin of the blob URL</a> <var>url</var>.
 
  <li><p>Return <var>url</var>.
 </ol>

--- a/url.bs
+++ b/url.bs
@@ -1129,6 +1129,7 @@ refers to as well as its origin. It is important that these are cached as the <a
 be removed from the <a>blob URL store</a> between parsing and fetching, while fetching will still
 need to succeed.
 
+
 <h3 id=url-miscellaneous>URL miscellaneous</h3>
 
 <p>A <dfn export>special scheme</dfn> is a <a for=url>scheme</a> listed in the first column of

--- a/url.bs
+++ b/url.bs
@@ -1130,7 +1130,7 @@ that is null, a {{Blob}} object, or a {{MediaSource}} object. It is initially nu
 "object".
 
 <p>A <a for=/>URL</a> also has an associated
-<dfn for=url>cached origin</dfn> that is either null or a <a>ASCII string</a>.
+<dfn for=url>object origin</dfn> that is either null or an <a>ASCII string</a>.
 It is initially null.
 
 <p class="note">This is used to support caching the origin of a "<code>blob</code>"
@@ -1435,11 +1435,12 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
  <li><p>If <var>url</var>'s <a for=url>scheme</a> is not
  "<code>blob</code>", return <var>url</var>.
 
- <li><p>Set <var>url</var>'s <a for=url>cached origin</a> to the result of
+ <li><p>Set <var>url</var>'s <a for=url>object origin</a> to the result of
  <a for="blob URL" lt="resolve the origin">resolving the origin of the blob URL</a> <var>url</var>.
 
  <li><p>Set <var>url</var>'s <a for=url>object</a> to the result of
- <a for="blob URL" lt="resolve">resolving the blob URL</a> <var>url</var>.
+ <a for="blob URL" lt="resolve">resolving the blob URL</a> <var>url</var>,
+ or null if that returned failure.
 
  <li><p>Return <var>url</var>.
 </ol>
@@ -2442,8 +2443,8 @@ background information. [[!HTML]]
 <dl class=switch>
  <dt>"<code>blob</code>"
  <dd>
-  If <a for=/>URL</a>'s <a for=url>cached origin</a> is not null, return
-  <a for=/>URL</a>'s <a for=url>cached origin</a>.
+  If <a for=/>URL</a>'s <a for=url>object origin</a> is not null, return
+  <a for=/>URL</a>'s <a for=url>object origin</a>.
 
   <p>Return the result of <a for="blob URL" lt="resolve the origin">resolving the origin of the blob URL</a>.
   <!-- Did you mean: recursion -->
@@ -3271,6 +3272,7 @@ Larry Masinter,
 Leif Halvard Silli,
 Mark Davis,
 Marcos Cáceres,
+Marijn Kruisselbrink,
 Martin Dürst,
 Mathias Bynens,
 Michael Peick,


### PR DESCRIPTION
This fixes #290, fixes #127, fixes w3c/FileAPI#20 and fixes w3c/FileAPI#63.

The only observable change here is the origin for blob URLs created in unique origins (which is only observable indirectly by trying to fetch such URLs), and tests for that already exist in https://w3c-test.org/FileAPI/url/sandboxed-iframe.html.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/371.html" title="Last updated on Jan 11, 2019, 9:19 AM UTC (8b426c4)">Preview</a> | <a href="https://whatpr.org/url/371/07ecb3b...8b426c4.html" title="Last updated on Jan 11, 2019, 9:19 AM UTC (8b426c4)">Diff</a>