### PR TITLE
Fix an example: new URL("https://domain/#frag") succeeds.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2627,7 +2627,7 @@ var input = "https://example.org/💩",
     url = new URL(input)
 url.pathname // "/%F0%9F%92%A9"</code></pre>
 
- <p>This throws an exception if the input is not an <a>absolute-URL string</a>:
+ <p>This throws an exception if the input is not an <a>absolute-URL-with-fragment string</a>:
 
  <pre><code class="lang-javascript">
 try {
@@ -3127,6 +3127,7 @@ James Graham,
 James Manger,
 James Ross,
 Jeffrey Posnick,
+Jeffrey Yasskin,
 Joe Duarte,
 Joshua Bell,
 Jxck,


### PR DESCRIPTION
This works in Chrome, and I think it's what the spec says, but I don't see a matching test in web-platform-tests.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/376.html" title="Last updated on Mar 24, 2018, 9:32 PM GMT (c61c08b)">Preview</a> | <a href="https://whatpr.org/url/376/5fc4c4c...c61c08b.html" title="Last updated on Mar 24, 2018, 9:32 PM GMT (c61c08b)">Diff</a>