### PR TITLE
URL's object can no longer be a MediaStream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 deploy_key
 deploy_key.pub
 url.html
+deploy.sh

--- a/url.bs
+++ b/url.bs
@@ -56,7 +56,6 @@ might increase in scope somewhat.
  <li>File API [[!FILEAPI]]
  <li>HTML Standard [[!HTML]]
  <li>Media Source Extensions [[!MEDIA-SOURCE]]
- <li>Media Capture and Streams [[!MEDIACAPTURE-STREAMS]]
  <li>Unicode IDNA Compatibility Processing [[!UTS46]]
  <li>Web IDL [[!WEBIDL]]
 </ul>
@@ -1001,12 +1000,10 @@ resource the <a for=/>URL</a>'s other components identify. It is initially null.
 <p id=non-relative-flag>A <a for=/>URL</a> also has an associated
 <dfn export for=url>cannot-be-a-base-URL flag</dfn>. It is initially unset.
 
-<p>A <a for=/>URL</a> also has an associated
-<dfn export for=url id=concept-url-object>object</dfn> that is null, a {{Blob}} object, a
-{{MediaSource}} object, or a {{MediaStream}} object. It is initially null.
+<p>A <a for=/>URL</a> also has an associated <dfn export for=url id=concept-url-object>object</dfn>
+that is null, a {{Blob}} object, or a {{MediaSource}} object. It is initially null.
 [[!FILEAPI]]
 [[!MEDIA-SOURCE]]
-[[!MEDIACAPTURE-STREAMS]]
 
 <p class="note no-backref">At this point this is used primarily to support
 "<code>blob</code>" <a for=/>URLs</a>, but others can be added going forward, hence
@@ -3185,8 +3182,6 @@ for being awesome!
 <pre class=anchors>
 spec: MEDIA-SOURCE; urlPrefix: https://w3c.github.io/media-source/#idl-def-
     type: interface; text: MediaSource
-spec: MEDIACAPTURE-STREAMS; urlPrefix: https://w3c.github.io/mediacapture-main/#idl-def-
-    type: interface; text: MediaStream
 spec: UTS46; urlPrefix: https://www.unicode.org/reports/tr46/
     type: abstract-op; text: ToASCII; url: #ToASCII
     type: abstract-op; text: ToUnicode; url: #ToUnicode


### PR DESCRIPTION
This feature was removed in 2013 from Media Capture and Streams and is being removed from browsers (already gone in Safari).

Tests: https://github.com/w3c/web-platform-tests/pull/10515.

Fixes #380.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/381.html" title="Last updated on Apr 20, 2018, 4:41 PM GMT (ff13957)">Preview</a> | <a href="https://whatpr.org/url/381/a1b789c...ff13957.html" title="Last updated on Apr 20, 2018, 4:41 PM GMT (ff13957)">Diff</a>