### PR TITLE
Remove _charset_ handling.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2495,17 +2495,8 @@ takes a list of name-value or name-value-type tuples <var>tuples</var>, optional
 
    <li><p>Let <var>value</var> be <var>tuple</var>'s value.
 
-   <li>
-    <p>If <var>tuple</var> has a type, then:
-
-    <ol>
-     <li><p>If <var>tuple</var>'s type is "<code>hidden</code>" and <var>name</var> is
-     "<code>_charset_</code>", then set <var>value</var> to <var>encoding</var>'s
-     <a for=encoding>name</a>.
-
-     <li><p>Otherwise, if <var>tuple</var>'s type is "<code>file</code>", then set <var>value</var>
-     to <var>value</var>'s filename.
-    </ol>
+   <li><p>If <var>tuple</var> has a type, and it is "<code>file</code>", then
+   set <var>value</var> to <var>value</var>'s filename.
 
    <li><p>Set <var>value</var> to the result of <a lt="urlencoded byte serializer">serializing</a>
    the result of <a lt=encode>encoding</a> <var>value</var>, using <var>encoding</var>.


### PR DESCRIPTION
We don't need to handle _charset_ in application/x-www-form-urlencoded
serializer because it should be done in "construct the form data set"
steps in the HTML specification.

This fixes https://github.com/whatwg/html/issues/3560.