### PR TITLE
Remove 'type' from from data entries.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2510,8 +2510,8 @@ override</var>, and then runs these steps:
  <li>Return <var>output</var>.
 </ol>
 
-<p class="note no-backref">The <cite>HTML standard</cite> invokes this algorithm with name-value
-tuples. [[HTML]]
+<p class="note no-backref">The <cite>HTML standard</cite> invokes this algorithm with values that are files.
+[[HTML]]</p>
 
 
 <h3 id=urlencoded-hooks>Hooks</h3>

--- a/url.bs
+++ b/url.bs
@@ -2475,8 +2475,8 @@ takes a byte sequence <var>input</var> and then runs these steps:
 
 <p>The
 <dfn export id=concept-urlencoded-serializer lt='urlencoded serializer'><code>application/x-www-form-urlencoded</code> serializer</dfn>
-takes a list of name-value or name-value tuples <var>tuples</var>, optionally with an
-<a for=/>encoding</a> <var>encoding override</var>, and then runs these steps:
+takes a list of name-value tuples <var>tuples</var>, optionally with an <a for=/>encoding</a> <var>encoding
+override</var>, and then runs these steps:
 
 <ol>
  <li><p>Let <var>encoding</var> be <a>UTF-8</a>.

--- a/url.bs
+++ b/url.bs
@@ -2475,7 +2475,7 @@ takes a byte sequence <var>input</var> and then runs these steps:
 
 <p>The
 <dfn export id=concept-urlencoded-serializer lt='urlencoded serializer'><code>application/x-www-form-urlencoded</code> serializer</dfn>
-takes a list of name-value or name-value-type tuples <var>tuples</var>, optionally with an
+takes a list of name-value or name-value tuples <var>tuples</var>, optionally with an
 <a for=/>encoding</a> <var>encoding override</var>, and then runs these steps:
 
 <ol>
@@ -2495,8 +2495,7 @@ takes a list of name-value or name-value-type tuples <var>tuples</var>, optional
 
    <li><p>Let <var>value</var> be <var>tuple</var>'s value.
 
-   <li><p>If <var>tuple</var> has a type and it is "<code>file</code>", then set <var>value</var> to
-   <var>value</var>'s filename.
+   <li><p>If <var>value</var> is a file, then set <var>value</var> to <var>value</var>'s filename.
 
    <li><p>Set <var>value</var> to the result of <a lt="urlencoded byte serializer">serializing</a>
    the result of <a lt=encode>encoding</a> <var>value</var>, using <var>encoding</var>.

--- a/url.bs
+++ b/url.bs
@@ -2510,8 +2510,8 @@ takes a list of name-value or name-value tuples <var>tuples</var>, optionally wi
  <li>Return <var>output</var>.
 </ol>
 
-<p class="note no-backref">The <cite>HTML standard</cite> invokes this algorithm with
-name-value tuples. [[HTML]]
+<p class="note no-backref">The <cite>HTML standard</cite> invokes this algorithm with name-value
+tuples. [[HTML]]
 
 
 <h3 id=urlencoded-hooks>Hooks</h3>

--- a/url.bs
+++ b/url.bs
@@ -2475,8 +2475,8 @@ takes a byte sequence <var>input</var> and then runs these steps:
 
 <p>The
 <dfn export id=concept-urlencoded-serializer lt='urlencoded serializer'><code>application/x-www-form-urlencoded</code> serializer</dfn>
-takes a list of name-value tuples <var>tuples</var>, optionally with an <a for=/>encoding</a> <var>encoding
-override</var>, and then runs these steps:
+takes a list of name-value tuples <var>tuples</var>, optionally with an <a for=/>encoding</a>
+<var>encoding override</var>, and then runs these steps:
 
 <ol>
  <li><p>Let <var>encoding</var> be <a>UTF-8</a>.
@@ -2510,8 +2510,8 @@ override</var>, and then runs these steps:
  <li>Return <var>output</var>.
 </ol>
 
-<p class="note no-backref">The <cite>HTML standard</cite> invokes this algorithm with values that are files.
-[[HTML]]</p>
+<p class="note no-backref">The <cite>HTML standard</cite> invokes this algorithm with values that
+are files. [[HTML]]
 
 
 <h3 id=urlencoded-hooks>Hooks</h3>

--- a/url.bs
+++ b/url.bs
@@ -2511,7 +2511,7 @@ takes a list of name-value or name-value tuples <var>tuples</var>, optionally wi
 </ol>
 
 <p class="note no-backref">The <cite>HTML standard</cite> invokes this algorithm with
-name-value-type tuples. [[HTML]]
+name-value tuples. [[HTML]]
 
 
 <h3 id=urlencoded-hooks>Hooks</h3>


### PR DESCRIPTION
This fixes https://github.com/whatwg/html/issues/3648.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/384.html" title="Last updated on May 8, 2018, 9:05 AM GMT (eeea22e)">Preview</a> | <a href="https://whatpr.org/url/384/5c0d2ec...eeea22e.html" title="Last updated on May 8, 2018, 9:05 AM GMT (eeea22e)">Diff</a>