### PR TITLE
Change query state slightly to better deal with non-UTF-8 encodings

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2116,34 +2116,12 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
       <p>then set <var>encoding</var> to <a>UTF-8</a>.
       <!-- https://simon.html5.org/test/url/url-encoding.html -->
 
-     <li>
-      <p>If <a>c</a> is the <a>EOF code point</a>, or <var>state override</var> is not given and
-      <a>c</a> is U+0023 (#), then:
-
-      <ol>
-       <li><p>Set <var>buffer</var> to the result of <a lt=encode>encoding</a> <var>buffer</var>
-       using <var>encoding</var>.
-
-       <li>
-        <p>For each <var>byte</var> in <var>buffer</var>:
-
-        <ol>
-         <li><p>If <var>byte</var> is less than 0x21 (!), greater than 0x7E (~), or is 0x22 ("),
-         0x23 (#), 0x3C (&lt;), or 0x3E (>), append <var>byte</var>,
-         <a lt="percent encode">percent encoded</a>, to <var>url</var>'s <a for=url>query</a>.
-
-         <li><p>Otherwise, append a code point whose value is <var>byte</var> to
-         <var>url</var>'s <a for=url>query</a>.
-        </ol>
-
-       <li><p>Set <var>buffer</var> to the empty string.
-
-       <li><p>If <a>c</a> is U+0023 (#), then set <var>url</var>'s <a for=url>fragment</a> to the
-       empty string and state to <a>fragment state</a>.
-      </ol>
+     <li><p>If <var>state override</var> is not given and <a>c</a> is U+0023 (#), then set
+     <var>url</var>'s <a for=url>fragment</a> to the empty string and state to
+     <a>fragment state</a>.
 
      <li>
-      <p>Otherwise:
+      <p>Otherwise, if <a>c</a> is not the <a>EOF code point</a>:
 
       <ol>
        <li><p>If <a>c</a> is not a <a>URL code point</a> and not U+0025 (%),
@@ -2152,7 +2130,44 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
        <li><p>If <a>c</a> is U+0025 (%) and <a>remaining</a> does not start with two
        <a>ASCII hex digits</a>, <a>validation error</a>.
 
-       <li><p>Append <a>c</a> to <var>buffer</var>.
+       <li><p>Let <var>bytes</var> be the result of <a lt=encode>encoding</a> <a>c</a> using
+       <var>encoding</var>.
+
+       <li>
+        <p>If <var>bytes</var> starts with `<code>&amp;#</code>` and ends with 0x3B (;), then:
+
+        <ol>
+         <li><p>Replace `<code>&amp;#</code>` at the start of <var>bytes</var> with
+         `<code>%26%23</code>`.
+
+         <li><p>Replace 0x3B (;) at the end of <var>bytes</var> with `<code>%3B</code>`.
+
+         <li><p>Append <var>bytes</var>, <a>isomorphic decoded</a>, to <var>url</var>'s
+         <a for=url>query</a>.
+        </ol>
+
+        <p class="note no-backref">This can happen when <a lt=encode>encoding</a> code points using
+        a non-<a>UTF-8</a> <a for=/>encoding</a>.
+
+       <li>
+        <p>Otherwise, for each <var>byte</var> in <var>bytes</var>:
+
+        <ol>
+         <li>
+          <p>If one of the following is true
+
+          <ul class=brief>
+           <li><p><var>byte</var> is less than 0x21 (!)
+           <li><p><var>byte</var> is greater than 0x7E (~)
+           <li><p><var>byte</var> is 0x22 ("), 0x23 (#), 0x3C (&lt;), or 0x3E (>)
+          </ul>
+
+          <p>then append <var>byte</var>, <a lt="percent encode">percent encoded</a>, to
+          <var>url</var>'s <a for=url>query</a>.
+
+         <li><p>Otherwise, append a code point whose value is <var>byte</var> to
+         <var>url</var>'s <a for=url>query</a>.
+        </ol>
       </ol>
     </ol>
 

--- a/url.bs
+++ b/url.bs
@@ -2106,15 +2106,21 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
    <dd>
     <ol>
      <li>
+      <p>If <var>encoding</var> is not <a>UTF-8</a> and one of the following is true
+
+      <ul class=brief>
+       <li><p><var>url</var> <a lt="is special">is not special</a>
+       <li><p><var>url</var>'s <a for=url>scheme</a> is "<code>ws</code>" or "<code>wss</code>"
+      </ul>
+
+      <p>then set <var>encoding</var> to <a>UTF-8</a>.
+      <!-- https://simon.html5.org/test/url/url-encoding.html -->
+
+     <li>
       <p>If <a>c</a> is the <a>EOF code point</a>, or <var>state override</var> is not given and
       <a>c</a> is U+0023 (#), then:
 
       <ol>
-       <li><p>If <var>url</var> <a lt="is special">is <em>not</em> special</a> or <var>url</var>'s
-       <a for=url>scheme</a> is either "<code>ws</code>" or "<code>wss</code>", set
-       <var>encoding</var> to <a>UTF-8</a>.
-       <!-- https://simon.html5.org/test/url/url-encoding.html -->
-
        <li><p>Set <var>buffer</var> to the result of <a lt=encode>encoding</a> <var>buffer</var>
        using <var>encoding</var>.
 


### PR DESCRIPTION
If the input to the URL parser contains code points outside the non-UTF-8 encoding's value space and the URL parser was invoked using a non-UTF-8 encoding, then those code points end up as &#...;.

The problem is that &, #, and ; are also URL separators, but the previous algorithm would only encode #. This ensures that & and ; are also encoded, as some browsers already do, but only if they came about as the result of the encode operation.

Tests: [we need to make a number of test changes for this]


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/386.html" title="Last updated on May 23, 2018, 6:41 AM GMT (2518aa4)">Preview</a> | <a href="https://whatpr.org/url/386/acc2bf4...2518aa4.html" title="Last updated on May 23, 2018, 6:41 AM GMT (2518aa4)">Diff</a>