### PR TITLE
Define hosts' public suffix and registrable domain.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -272,6 +272,97 @@ for further processing.
 U+0020 SPACE, U+0023 (#), U+0025 (%), U+002F (/), U+003A (:), U+003F (?), U+0040 (@), U+005B ([),
 U+005C (\), or U+005D (]).
 
+<p>A <a for=/>host</a>'s <dfn for=host export id=concept-host-public-suffix>public suffix</dfn> is
+the portion of a <a for=/>host</a> which is controlled by a registrar, public or otherwise. To
+obtain <var>host</var>'s <a for=host>public suffix</a>, run the following steps:
+
+<ol>
+ <li><p>Let <var>parsed</var> be the result of <a lt="host parser">host parsing</a> <var>host</var>.
+
+ <li><p>If <var>parsed</var> is not a <a>domain</a>, return the empty string.
+
+ <li><p>Return the <a for=host>public suffix</a> obtained by executing the
+ <a href="https://publicsuffix.org/list/">algorithm</a> defined by the Public Suffix List. [[!PSL]].
+</ol>
+
+<p>A <a for=/>host</a>'s <dfn for=host export id=concept-host-registrable-domain>registrable
+domain</dfn> is a formally valid domain name that could be registered at a registry. To obtain
+<var>host</var>'s <a for=host>registrable domain</a>, run the following steps:
+
+<ol>
+ <li><p>Let <var>parsed</var> be the result of <a lt="host parser">host parsing</a> <var>host</var>.
+
+ <li><p>If <var>parsed</var> is not a <a>domain</a>, return the empty string.
+
+ <li><p>If <var>parsed</var>'s <a for=host>public suffix</a> is <var>host</var>, return the empty
+ string.
+
+ <li><p>Return the <a for=host>registrable domain</a> obtained by executing the
+ <a href="https://publicsuffix.org/list/">algorithm</a> defined by the Public Suffix List. [[!PSL]].
+</ol>
+
+<div class=example id=example-host-psl>
+ <table>
+  <tr>
+   <th>Host
+   <th>Public Suffix
+   <th>Registrable Domain
+  <tr>
+   <td><code>com</code>
+   <td><code>com</code>
+   <td>
+  <tr>
+   <td><code>example.com</code>
+   <td><code>com</code>
+   <td><code>example.com</code>
+  <tr>
+   <td><code>www.example.com</code>
+   <td><code>com</code>
+   <td><code>example.com</code>
+  <tr>
+   <td><code>sub.www.example.com</code>
+   <td><code>com</code>
+   <td><code>example.com</code>
+  <tr>
+   <td><code>EXAMPLE.COM</code>
+   <td><code>com</code>
+   <td><code>example.com</code>
+  <tr>
+   <td><code>github.io</code>
+   <td><code>github.io</code>
+   <td>
+  <tr>
+   <td><code>whatwg.github.io</code>
+   <td><code>github.io</code>
+   <td><code>whatwg.github.io</code>
+  <tr>
+   <td><code>whatwg.github.io</code>
+   <td><code>github.io</code>
+   <td><code>whatwg.github.io</code>
+  <tr>
+   <td><code>إختبار</code>
+   <td><code>xn-kgbechtv</code>
+   <td>
+  <tr>
+   <td><code>example.إختبار</code>
+   <td><code>xn-kgbechtv</code>
+   <td><code>example.xn-kgbechtv</code>
+  <tr>
+   <td><code>sub.example.إختبار</code>
+   <td><code>xn-kgbechtv</code>
+   <td><code>example.xn-kgbechtv</code>
+ </table>
+</div>
+
+<p>Two <a for=/>hosts</a>, <var>A</var> and <var>B</var> are said to be
+<dfn for=host export id=concept-host-same-site>same-site</dfn> with each other if either of the
+following statements are true:
+
+<ul class=brief>
+ <li><p><var>A</var> is identical to <var>B</var>
+ <li><p><var>A</var>'s <a for=host>registrable domain</a> is not the empty string, and is identical
+ to <var>B</var>'s <a for=host>registrable domain</a>.
+</ul>
 
 <h3 id=idna>IDNA</h3>
 

--- a/url.bs
+++ b/url.bs
@@ -284,9 +284,10 @@ U+005C (\), or U+005D (]).
  <var>host</var>. [[!PSL]].
 </ol>
 
-<p>A <a for=/>host</a>'s <dfn for=host export>registrable domain</dfn> is a <a>domain</a> that could
-be registered at a registry. To obtain <var>host</var>'s <a for=host>registrable domain</a>, run
-these steps:
+<p>A <a for=/>host</a>'s <dfn for=host export>registrable domain</dfn> is a <a>domain</a> formed by
+the most specific public suffix, along with the domain label immediately preceeding it. If no such
+label is available, the <a for=host>registrable domain</a> is null. To obtain <var>host</var>'s
+<a for=host>registrable domain</a>, run these steps:
 
 <ol>
  <li><p>If <var>host</var>'s <a for=host>public suffix</a> is null or <var>host</var>'s
@@ -384,7 +385,11 @@ these steps:
 
 <p class=warning>Specifications should avoid relying on "<a for=host>public suffix</a>",
 "<a for=host>registrable domain</a>", and "<a>same site</a>". The public suffix list will diverge
-from client to client, and cannot be relied-upon to provide a hard security boundary.</p>
+from client to client, and cannot be relied-upon to provide a hard security boundary. Specifications
+which ignore this advice are encouraged to carefully consider whether URLs' schemes ought to be
+incorporated into any decision made based upon whether or not two <a for=/>hosts</a> are <a>same
+site</a>. HTML's <a>same origin-domain</a> concept is a reasonable example of this consideration in
+practice.
 
 
 <h3 id=idna>IDNA</h3>

--- a/url.bs
+++ b/url.bs
@@ -364,13 +364,13 @@ obtain <var>host</var>'s <a for=host>registrable domain</a>, run these steps:
  <ul>
   <li><p><code>example.com</code>, <code>sub.example.com</code>, <code>other.example.com</code>,
   <code>sub.sub.example.com</code>, and <code>sub.other.example.com</code> are all <a>same site</a>
-  with each other (and themselves), as each their <a for=host>registrable domain</a> is
+  with each other (and themselves), as their <a for=host>registrable domains</a> are
   <code>example.com</code>.
 
   <li><p><code>registrable.suffix.example</code>, <code>sub.registrable.suffix.example</code>,
   <code>other.registrable.suffix.example</code>, <code>sub.sub.registrable.suffix.example</code>,
   and <code>sub.other.registrable.suffix.example</code> are all <a>same site</a> with each other
-  (and themselves), as each their <a for=host>registrable domain</a> is
+  (and themselves), as their <a for=host>registrable domains</a> are
   <code>registrable.suffix.example</code>.
 
   <li><p><code>example.com</code> and <code>registrable.suffix.example</code> are not

--- a/url.bs
+++ b/url.bs
@@ -273,8 +273,8 @@ U+0020 SPACE, U+0023 (#), U+0025 (%), U+002F (/), U+003A (:), U+003F (?), U+0040
 U+005C (\), or U+005D (]).
 
 <p>A <a for=/>host</a>'s <dfn for=host export>public suffix</dfn> is the portion of a
-<a for=/>host</a> which is included on the Public Suffix List [[!PSL]]. To obtain
-<var>host</var>'s <a for=host>public suffix</a>, run these steps:
+<a for=/>host</a> which is included on the <cite>Public Suffix List</cite>. To obtain
+<var>host</var>'s <a for=host>public suffix</a>, run these steps: [[!PSL]]
 
 <ol>
  <li><p>If <var>host</var> is not a <a>domain</a>, then return null.
@@ -285,9 +285,8 @@ U+005C (\), or U+005D (]).
 </ol>
 
 <p>A <a for=/>host</a>'s <dfn for=host export>registrable domain</dfn> is a <a>domain</a> formed by
-the most specific public suffix, along with the domain label immediately preceeding it. If no such
-label is available, the <a for=host>registrable domain</a> is null. To obtain <var>host</var>'s
-<a for=host>registrable domain</a>, run these steps:
+the most specific public suffix, along with the domain label immediately preceeding it, if any. To
+obtain <var>host</var>'s <a for=host>registrable domain</a>, run these steps:
 
 <ol>
  <li><p>If <var>host</var>'s <a for=host>public suffix</a> is null or <var>host</var>'s
@@ -295,7 +294,7 @@ label is available, the <a for=host>registrable domain</a> is null. To obtain <v
 
  <li><p>Return the <a for=host>registrable domain</a> obtained by executing the
  <a href="https://publicsuffix.org/list/">algorithm</a> defined by the Public Suffix List on
- <var>host</var>. [[!PSL]].
+ <var>host</var>. [[!PSL]]
 </ol>
 
 <div class=example id=example-host-psl>
@@ -351,45 +350,45 @@ label is available, the <a for=host>registrable domain</a> is null. To obtain <v
 <dfn for=host export>same site</dfn> with each other if either of the following statements are true:
 
 <ul class=brief>
- <li><p><var>A</var> <a for=host>equals</a> <var>B</var>, and <var>A</var>'s <a for=host>registrable
- domain</a> is not null.
+ <li><p><var>A</var> <a for=host>equals</a> <var>B</var> and <var>A</var>'s
+ <a for=host>registrable domain</a> is non-null.
 
  <li><p><var>A</var>'s <a for=host>registrable domain</a> is <var>B</var>'s
- <a for=host>registrable domain</a> and is not null.
+ <a for=host>registrable domain</a> and is non-null.
 </ul>
 
 <div class=example id=example-same-site>
- <p>Assuming that <code>suffix.example</code> is a <a for=host>public suffix</a>, and that
+ <p>Assuming that <code>suffix.example</code> is a <a for=host>public suffix</a> and that
  <code>example.com</code> is not:
 
  <ul>
   <li><p><code>example.com</code>, <code>sub.example.com</code>, <code>other.example.com</code>,
   <code>sub.sub.example.com</code>, and <code>sub.other.example.com</code> are all <a>same site</a>
-  with each other (and themselves), as each host's <a for=host>registrable domain</a> is
+  with each other (and themselves), as each their <a for=host>registrable domain</a> is
   <code>example.com</code>.
 
   <li><p><code>registrable.suffix.example</code>, <code>sub.registrable.suffix.example</code>,
   <code>other.registrable.suffix.example</code>, <code>sub.sub.registrable.suffix.example</code>,
   and <code>sub.other.registrable.suffix.example</code> are all <a>same site</a> with each other
-  (and themselves), as each host's <a for=host>registrable domain</a> is
+  (and themselves), as each their <a for=host>registrable domain</a> is
   <code>registrable.suffix.example</code>.
 
-  <li><p><code>example.com</code> and <code>registrable.suffix.example</code> are not <a>same
-  site</a> with each other, as their <a for=host>registrable domains</a> differ.
+  <li><p><code>example.com</code> and <code>registrable.suffix.example</code> are not
+  <a>same site</a> with each other, as their <a for=host>registrable domains</a> differ.
 
   <li><p><code>suffix.example</code> is not <a>same site</a> with <code>suffix.example</code>, as
-  it is a <a for=host>public suffix</a>, and therefore has a null <a for=host>registrable
-  domain</a>.
+  it is a <a for=host>public suffix</a>, and therefore has a null
+  <a for=host>registrable domain</a>.
  </ul>
 </div>
 
-<p class=warning>Specifications should avoid relying on "<a for=host>public suffix</a>",
+<p class=warning>Specifications should avoid depending on "<a for=host>public suffix</a>",
 "<a for=host>registrable domain</a>", and "<a>same site</a>". The public suffix list will diverge
 from client to client, and cannot be relied-upon to provide a hard security boundary. Specifications
 which ignore this advice are encouraged to carefully consider whether URLs' schemes ought to be
-incorporated into any decision made based upon whether or not two <a for=/>hosts</a> are <a>same
-site</a>. HTML's <a>same origin-domain</a> concept is a reasonable example of this consideration in
-practice.
+incorporated into any decision made based upon whether or not two <a for=/>hosts</a> are
+<a>same site</a>. HTML's <a>same origin-domain</a> concept is a reasonable example of this
+consideration in practice.
 
 
 <h3 id=idna>IDNA</h3>

--- a/url.bs
+++ b/url.bs
@@ -277,12 +277,11 @@ the portion of a <a for=/>host</a> which is controlled by a registrar, public or
 obtain <var>host</var>'s <a for=host>public suffix</a>, run the following steps:
 
 <ol>
- <li><p>Let <var>parsed</var> be the result of <a lt="host parser">host parsing</a> <var>host</var>.
-
- <li><p>If <var>parsed</var> is not a <a>domain</a>, return the empty string.
+ <li><p>If <var>host</var> is not a <a>domain</a>, return null.
 
  <li><p>Return the <a for=host>public suffix</a> obtained by executing the
- <a href="https://publicsuffix.org/list/">algorithm</a> defined by the Public Suffix List. [[!PSL]].
+ <a href="https://publicsuffix.org/list/">algorithm</a> defined by the Public Suffix List on
+ <var>host</var>. [[!PSL]].
 </ol>
 
 <p>A <a for=/>host</a>'s <dfn for=host export id=concept-host-registrable-domain>registrable
@@ -290,21 +289,18 @@ domain</dfn> is a formally valid domain name that could be registered at a regis
 <var>host</var>'s <a for=host>registrable domain</a>, run the following steps:
 
 <ol>
- <li><p>Let <var>parsed</var> be the result of <a lt="host parser">host parsing</a> <var>host</var>.
-
- <li><p>If <var>parsed</var> is not a <a>domain</a>, return the empty string.
-
- <li><p>If <var>parsed</var>'s <a for=host>public suffix</a> is <var>host</var>, return the empty
- string.
+ <li><p>If <var>host</var>'s <a for=host>public suffix</a> is null, or
+ <a lt=concept-host-equals>equals</a> <var>host</var>, return null.
 
  <li><p>Return the <a for=host>registrable domain</a> obtained by executing the
- <a href="https://publicsuffix.org/list/">algorithm</a> defined by the Public Suffix List. [[!PSL]].
+ <a href="https://publicsuffix.org/list/">algorithm</a> defined by the Public Suffix List on
+ <var>host</var>. [[!PSL]].
 </ol>
 
 <div class=example id=example-host-psl>
  <table>
   <tr>
-   <th>Host
+   <th>Host Input
    <th>Public Suffix
    <th>Registrable Domain
   <tr>
@@ -355,11 +351,11 @@ domain</dfn> is a formally valid domain name that could be registered at a regis
 </div>
 
 <p>Two <a for=/>hosts</a>, <var>A</var> and <var>B</var> are said to be
-<dfn for=host export id=concept-host-same-site>same-site</dfn> with each other if either of the
+<dfn for=host export id=concept-host-same-site>same site</dfn> with each other if either of the
 following statements are true:
 
 <ul class=brief>
- <li><p><var>A</var> is identical to <var>B</var>
+ <li><p><var>A</var> <a lt=concept-host-equals>equals</a> <var>B</var>
  <li><p><var>A</var>'s <a for=host>registrable domain</a> is not the empty string, and is identical
  to <var>B</var>'s <a for=host>registrable domain</a>.
 </ul>

--- a/url.bs
+++ b/url.bs
@@ -273,7 +273,7 @@ U+0020 SPACE, U+0023 (#), U+0025 (%), U+002F (/), U+003A (:), U+003F (?), U+0040
 U+005C (\), or U+005D (]).
 
 <p>A <a for=/>host</a>'s <dfn for=host export>public suffix</dfn> is the portion of a
-<a for=/>host</a> which is controlled by a registrar, public or otherwise. To obtain
+<a for=/>host</a> which is included on the Public Suffix List [[!PSL]]. To obtain
 <var>host</var>'s <a for=host>public suffix</a>, run these steps:
 
 <ol>
@@ -290,8 +290,7 @@ these steps:
 
 <ol>
  <li><p>If <var>host</var>'s <a for=host>public suffix</a> is null or <var>host</var>'s
- <a for=host>public suffix</a> <a lt=concept-host-equals>equals</a> <var>host</var>, then return
- null.
+ <a for=host>public suffix</a> <a for=host>equals</a> <var>host</var>, then return null.
 
  <li><p>Return the <a for=host>registrable domain</a> obtained by executing the
  <a href="https://publicsuffix.org/list/">algorithm</a> defined by the Public Suffix List on
@@ -307,7 +306,7 @@ these steps:
   <tr>
    <td><code>com</code>
    <td><code>com</code>
-   <td>
+   <td><i>null</i>
   <tr>
    <td><code>example.com</code>
    <td><code>com</code>
@@ -327,11 +326,7 @@ these steps:
   <tr>
    <td><code>github.io</code>
    <td><code>github.io</code>
-   <td>
-  <tr>
-   <td><code>whatwg.github.io</code>
-   <td><code>github.io</code>
-   <td><code>whatwg.github.io</code>
+   <td><i>null</i>
   <tr>
    <td><code>whatwg.github.io</code>
    <td><code>github.io</code>
@@ -339,7 +334,7 @@ these steps:
   <tr>
    <td><code>إختبار</code>
    <td><code>xn-kgbechtv</code>
-   <td>
+   <td><i>null</i>
   <tr>
    <td><code>example.إختبار</code>
    <td><code>xn-kgbechtv</code>
@@ -355,10 +350,41 @@ these steps:
 <dfn for=host export>same site</dfn> with each other if either of the following statements are true:
 
 <ul class=brief>
- <li><p><var>A</var> <a lt=concept-host-equals>equals</a> <var>B</var>
+ <li><p><var>A</var> <a for=host>equals</a> <var>B</var>, and <var>A</var>'s <a for=host>registrable
+ domain</a> is not null.
+
  <li><p><var>A</var>'s <a for=host>registrable domain</a> is <var>B</var>'s
  <a for=host>registrable domain</a> and is not null.
 </ul>
+
+<div class=example id=example-same-site>
+ <p>Assuming that <code>suffix.example</code> is a <a for=host>public suffix</a>, and that
+ <code>example.com</code> is not:
+
+ <ul>
+  <li><p><code>example.com</code>, <code>sub.example.com</code>, <code>other.example.com</code>,
+  <code>sub.sub.example.com</code>, and <code>sub.other.example.com</code> are all <a>same site</a>
+  with each other (and themselves), as each host's <a for=host>registrable domain</a> is
+  <code>example.com</code>.
+
+  <li><p><code>registrable.suffix.example</code>, <code>sub.registrable.suffix.example</code>,
+  <code>other.registrable.suffix.example</code>, <code>sub.sub.registrable.suffix.example</code>,
+  and <code>sub.other.registrable.suffix.example</code> are all <a>same site</a> with each other
+  (and themselves), as each host's <a for=host>registrable domain</a> is
+  <code>registrable.suffix.example</code>.
+
+  <li><p><code>example.com</code> and <code>registrable.suffix.example</code> are not <a>same
+  site</a> with each other, as their <a for=host>registrable domains</a> differ.
+
+  <li><p><code>suffix.example</code> is not <a>same site</a> with <code>suffix.example</code>, as
+  it is a <a for=host>public suffix</a>, and therefore has a null <a for=host>registrable
+  domain</a>.
+ </ul>
+</div>
+
+<p class=warning>Specifications should avoid relying on "<a for=host>public suffix</a>",
+"<a for=host>registrable domain</a>", and "<a>same site</a>". The public suffix list will diverge
+from client to client, and cannot be relied-upon to provide a hard security boundary.</p>
 
 
 <h3 id=idna>IDNA</h3>

--- a/url.bs
+++ b/url.bs
@@ -272,25 +272,26 @@ for further processing.
 U+0020 SPACE, U+0023 (#), U+0025 (%), U+002F (/), U+003A (:), U+003F (?), U+0040 (@), U+005B ([),
 U+005C (\), or U+005D (]).
 
-<p>A <a for=/>host</a>'s <dfn for=host export id=concept-host-public-suffix>public suffix</dfn> is
-the portion of a <a for=/>host</a> which is controlled by a registrar, public or otherwise. To
-obtain <var>host</var>'s <a for=host>public suffix</a>, run the following steps:
+<p>A <a for=/>host</a>'s <dfn for=host export>public suffix</dfn> is the portion of a
+<a for=/>host</a> which is controlled by a registrar, public or otherwise. To obtain
+<var>host</var>'s <a for=host>public suffix</a>, run these steps:
 
 <ol>
- <li><p>If <var>host</var> is not a <a>domain</a>, return null.
+ <li><p>If <var>host</var> is not a <a>domain</a>, then return null.
 
  <li><p>Return the <a for=host>public suffix</a> obtained by executing the
  <a href="https://publicsuffix.org/list/">algorithm</a> defined by the Public Suffix List on
  <var>host</var>. [[!PSL]].
 </ol>
 
-<p>A <a for=/>host</a>'s <dfn for=host export id=concept-host-registrable-domain>registrable
-domain</dfn> is a formally valid domain name that could be registered at a registry. To obtain
-<var>host</var>'s <a for=host>registrable domain</a>, run the following steps:
+<p>A <a for=/>host</a>'s <dfn for=host export>registrable domain</dfn> is a <a>domain</a> that could
+be registered at a registry. To obtain <var>host</var>'s <a for=host>registrable domain</a>, run
+these steps:
 
 <ol>
- <li><p>If <var>host</var>'s <a for=host>public suffix</a> is null, or
- <a lt=concept-host-equals>equals</a> <var>host</var>, return null.
+ <li><p>If <var>host</var>'s <a for=host>public suffix</a> is null or <var>host</var>'s
+ <a for=host>public suffix</a> <a lt=concept-host-equals>equals</a> <var>host</var>, then return
+ null.
 
  <li><p>Return the <a for=host>registrable domain</a> obtained by executing the
  <a href="https://publicsuffix.org/list/">algorithm</a> defined by the Public Suffix List on
@@ -300,9 +301,9 @@ domain</dfn> is a formally valid domain name that could be registered at a regis
 <div class=example id=example-host-psl>
  <table>
   <tr>
-   <th>Host Input
-   <th>Public Suffix
-   <th>Registrable Domain
+   <th>Host input
+   <th>Public suffix
+   <th>Registrable domain
   <tr>
    <td><code>com</code>
    <td><code>com</code>
@@ -351,14 +352,14 @@ domain</dfn> is a formally valid domain name that could be registered at a regis
 </div>
 
 <p>Two <a for=/>hosts</a>, <var>A</var> and <var>B</var> are said to be
-<dfn for=host export id=concept-host-same-site>same site</dfn> with each other if either of the
-following statements are true:
+<dfn for=host export>same site</dfn> with each other if either of the following statements are true:
 
 <ul class=brief>
  <li><p><var>A</var> <a lt=concept-host-equals>equals</a> <var>B</var>
- <li><p><var>A</var>'s <a for=host>registrable domain</a> is not the empty string, and is identical
- to <var>B</var>'s <a for=host>registrable domain</a>.
+ <li><p><var>A</var>'s <a for=host>registrable domain</a> is <var>B</var>'s
+ <a for=host>registrable domain</a> and is not null.
 </ul>
+
 
 <h3 id=idna>IDNA</h3>
 


### PR DESCRIPTION
This patch is another attempt at whatwg/url#72, and defers most of the actual work to the
algorithms defined at https://publicsuffix.org/list/.

I wonder if this is something we should expose on `URL` objects? I thikn @hillbrad was asking for it a looong time ago, but I don't know if he still has use cases.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/391.html" title="Last updated on Jun 4, 2018, 12:45 PM GMT (8828de3)">Preview</a> | <a href="https://whatpr.org/url/391/f0e4390...8828de3.html" title="Last updated on Jun 4, 2018, 12:45 PM GMT (8828de3)">Diff</a>