### PR TITLE
url.bs:  Fix to strange, undocumented deviance from RFC 3986 regarding URL encoding.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2469,7 +2469,7 @@ takes a byte sequence <var>input</var> and then runs these steps:
    <dt>0x20 (SP)
    <dd><p>Append U+002B (+) to <var>output</var>.
 
-   <dt>0x2A (*)
+   <dt>0x7E (~)
    <dt>0x2D (-)
    <dt>0x2E (.)
    <dt>0x30 (0) to 0x39 (9)


### PR DESCRIPTION
Per RFC 3986 published in 2005, the * is a reserved character.  That means that it must
be encoded if it is intended to be interpreted as a data item instead of a delimiter in
the context in which it appears.  Therefore it cannot be excluded from the set of
characters that require encoding.

However, the ~ is an unreserved character.  It is not to be used as a delimiter, and does
not require percent-encoding.

per the RFC:
 ... For consistency, percent-encoded octets in the ranges of ALPHA
   (%41-%5A and %61-%7A), DIGIT (%30-%39), hyphen (%2D), period (%2E),
   underscore (%5F), or tilde (%7E) should NOT be created by URI
   producers... 

The serialization scheme currently recommended in this standard encodes the tilde ( an unreserved character ) and does not encode the * ( a reserved character ).

From my perspective, the behavior of the serialization scheme recommended here should be the opposite of what it currently is regarding the two characters * and ~.

I can see no sensible supporting cases, documentation,  or justification anywhere that supports this standard's deviation from RFC 3986 regarding these two characters.

The change I made swaps the recommended behavior regarding these two chars.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/394.html" title="Last updated on Jun 6, 2018, 3:15 PM GMT (d5da430)">Preview</a> | <a href="https://whatpr.org/url/394/ac532ae...d5da430.html" title="Last updated on Jun 6, 2018, 3:15 PM GMT (d5da430)">Diff</a>