### PR TITLE
percent-encode ' in queries of URLs with special schemes

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2163,6 +2163,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
            <li><p><var>byte</var> is less than 0x21 (!)
            <li><p><var>byte</var> is greater than 0x7E (~)
            <li><p><var>byte</var> is 0x22 ("), 0x23 (#), 0x3C (&lt;), or 0x3E (>)
+           <li><p><var>byte</var> is 0x27 (') and <var>url</var> <a>is special</a>
           </ul>
 
           <p>then append <var>byte</var>, <a lt="percent encode">percent encoded</a>, to


### PR DESCRIPTION
Tests: https://github.com/web-platform-tests/wpt/pull/11389

Fixes https://github.com/whatwg/url/issues/348


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/395.html" title="Last updated on Jun 6, 2018, 8:18 PM GMT (97ac46a)">Preview</a> | <a href="https://whatpr.org/url/395/ac532ae...97ac46a.html" title="Last updated on Jun 6, 2018, 8:18 PM GMT (97ac46a)">Diff</a>