### PR TITLE
Preserve use of Nontransitional processing for IDNA

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -402,7 +402,7 @@ consideration in practice.
  <li><p>Let <var>result</var> be the result of running <a abstract-op lt=ToASCII>Unicode ToASCII</a>
  with <i>domain_name</i> set to <var>domain</var>, <i>UseSTD3ASCIIRules</i> set to
  <var>beStrict</var>, <i>CheckHyphens</i> set to false, <i>CheckBidi</i> set to true,
- <i>CheckJoiners</i> set to true, <i>processing_option</i> set to <i>Nontransitional_Processing</i>,
+ <i>CheckJoiners</i> set to true, <i>Transitional_Processing</i> set to false,
  and <i>VerifyDnsLength</i> set to <var>beStrict</var>.
 
  <li><p>If <var>result</var> is a failure value, <a>validation error</a>, return failure.
@@ -417,7 +417,7 @@ consideration in practice.
  <li><p>Let <var>result</var> be the result of running
  <a abstract-op lt=ToUnicode>Unicode ToUnicode</a> with <i>domain_name</i> set to <var>domain</var>,
  <i>CheckHyphens</i> set to false, <i>CheckBidi</i> set to true, <i>CheckJoiners</i> set to true,
- and <i>UseSTD3ASCIIRules</i> set to false.
+ <i>UseSTD3ASCIIRules</i> set to false, and <i>Transitional_Processing</i> set to false.
 
  <li><p>Signify <a>validation errors</a> for any returned errors, and then, return
  <var>result</var>.
@@ -441,7 +441,7 @@ consideration in practice.
  <li><p>Set <var>result</var> to the result of running
  <a abstract-op lt=ToUnicode>Unicode ToUnicode</a> with <i>domain_name</i> set to <var>result</var>,
  <i>CheckHyphens</i> set to false, <i>CheckBidi</i> set to true, <i>CheckJoiners</i> set to true,
- and <i>UseSTD3ASCIIRules</i> set to true.
+ <i>UseSTD3ASCIIRules</i> set to true, and <i>Transitional_Processing</i> set to false.
 
  <li><p>If <var>result</var> contains any errors, return failure.
 


### PR DESCRIPTION
As mentioned in https://github.com/whatwg/url/issues/400#issuecomment-406900069, the IDNA spec previously used Nontransitional Processing unconditionally in the ToUnicode algorithm. However, a recent spec change changed the ToUnicode algorithm to accept a boolean flag called *Transitional_Processing*, which allows the user to choose between Transitional and Nontransitional processing. This makes it so that the [domain to ASCII](https://url.spec.whatwg.org/#concept-domain-to-ascii), [domain to Unicode]( https://url.spec.whatwg.org/#concept-domain-to-unicode) algorithms, and [valid domain](https://url.spec.whatwg.org/#valid-domain) steps explicitly state the value for the *Transitional_Processing* flag, which preserves the previous behavior of using Nontransitional processing.

It also renames *processing_option* to *Transitional_Processing* in the  [domain to ASCII](https://url.spec.whatwg.org/#concept-domain-to-ascii) algorithm to match the latest spec changes. 

Fixes #400.

cc @annevk @TimothyGu


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/404.html" title="Last updated on Jul 23, 2018, 5:29 AM GMT (0d712a6)">Preview</a> | <a href="https://whatpr.org/url/404/6ef17eb...0d712a6.html" title="Last updated on Jul 23, 2018, 5:29 AM GMT (0d712a6)">Diff</a>