### PR TITLE
Specify that domains are ASCII strings.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -240,8 +240,8 @@ identifier in <a for=/>URLs</a> where a network address is not necessary.
 have no influence on <a for=/>host</a> writing, parsing, and serialization. Unless stated otherwise
 in the sections that follow.
 
-<p>A <dfn export id=concept-domain>domain</dfn> identifies a realm within a
-network.
+<p>A <dfn export id=concept-domain>domain</dfn> is an <a>ASCII string</a> that identifies a realm
+within a network.
 [[RFC1034]]
 
 <p class=note>The <code>example.com</code> and <code>example.com.</code> <a for=/>domains</a> are
@@ -393,7 +393,7 @@ consideration in practice.
 
 <h3 id=idna>IDNA</h3>
 
-<p>The <dfn id=concept-domain-to-ascii>domain to ASCII</dfn> algorithm, given a <a>domain</a>
+<p>The <dfn id=concept-domain-to-ascii>domain to ASCII</dfn> algorithm, given a <a>string</a>
 <var>domain</var> and optionally a boolean <var>beStrict</var>, runs these steps:
 
 <ol>
@@ -935,9 +935,9 @@ unified model would be, please file an issue.
  failure when given to the <a>URL parser</a>. I.e., input that would be considered conforming or
  valid.
 
- <li><p>The <a>URL serializer</a> takes a <a for=/>URL</a> and returns a string. (If that string
- is then <a lt="URL parser">parsed</a>, the result will <a for=url>equal</a> the <a for=/>URL</a>
- that was <a lt="URL serializer">serialized</a>.)
+ <li><p>The <a>URL serializer</a> takes a <a for=/>URL</a> and returns an <a>ASCII string</a>. (If
+ that string is then <a lt="URL parser">parsed</a>, the result will <a for=url>equal</a> the <a
+ for=/>URL</a> that was <a lt="URL serializer">serialized</a>.)
 </ul>
 
 <div class=example id=example-url-parsing>


### PR DESCRIPTION
This is the only part of the URL Serializer's output that wasn't already
specified to be ASCII.

I believe domains are always ASCII because:
* The URL Parser always sets a URL's host to the result of the host
  parser.
* The host parser on things other than IPv4, IPv6, and opaque hosts
  (i.e. "domains") returns |asciiDomain|, the result of 'domain to
  ASCII'.
* The URL.host setter passes its input through the URL parser.


I care because I want to know the right way to convert the result of the URL Serializer to a [header's value](https://fetch.spec.whatwg.org/#concept-header-value), a byte sequence.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/409.html" title="Last updated on Aug 3, 2018, 8:45 PM GMT (ff75aba)">Preview</a> | <a href="https://whatpr.org/url/409/6800342...ff75aba.html" title="Last updated on Aug 3, 2018, 8:45 PM GMT (ff75aba)">Diff</a>