### PR TITLE
Be clearer that URL serialization returns an ASCII string.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2347,7 +2347,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
 
 <p>The <dfn export id=concept-url-serializer lt="URL serializer">URL serializer</dfn> takes a
 <a for=/>URL</a> <var>url</var>, an optional <i title>exclude fragment flag</i>, and
-then runs these steps:
+then runs these steps, returning an <a>ASCII string</a>:
 
 <ol>
  <li><p>Let <var>output</var> be <var>url</var>'s <a for=url>scheme</a> and U+003A (:) concatenated.
@@ -2396,6 +2396,8 @@ then runs these steps:
  <li><p>If the <i title>exclude fragment flag</i> is unset and <var>url</var>'s
  <a for=url>fragment</a> is non-null, append U+0023 (#), followed by
  <var>url</var>'s <a for=url>fragment</a>, to <var>output</var>.
+
+ <li><p><a>Assert</a>: <var>output</var> is an <a>ASCII string</a>.
 
  <li><p>Return <var>output</var>.
 </ol>

--- a/url.bs
+++ b/url.bs
@@ -2397,8 +2397,6 @@ then runs these steps, returning an <a>ASCII string</a>:
  <a for=url>fragment</a> is non-null, append U+0023 (#), followed by
  <var>url</var>'s <a for=url>fragment</a>, to <var>output</var>.
 
- <li><p><a>Assert</a>: <var>output</var> is an <a>ASCII string</a>.
-
  <li><p>Return <var>output</var>.
 </ol>
 


### PR DESCRIPTION
I added this fact in the wrong place in #409: it ought to be on the definition of the [URL serializer](https://url.spec.whatwg.org/#concept-url-serializer) and not just [one of the uses](https://url.spec.whatwg.org/#ref-for-concept-url-serializer①). (I care because I just wasted a bit of time double-checking that it was true.)

I don't feel strongly about the `Assert` at the bottom of the algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/428.html" title="Last updated on Feb 7, 2019, 9:05 PM UTC (4d5ca88)">Preview</a> | <a href="https://whatpr.org/url/428/d2ef633...4d5ca88.html" title="Last updated on Feb 7, 2019, 9:05 PM UTC (4d5ca88)">Diff</a>