### PR TITLE
Suggest use of origin in warning text (Fixes #429)

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -382,13 +382,13 @@ obtain <var>host</var>'s <a for=host>registrable domain</a>, run these steps:
  </ul>
 </div>
 
-<p class=warning>Specifications should avoid depending on "<a for=host>public suffix</a>",
-"<a for=host>registrable domain</a>", and "<a>same site</a>". The public suffix list will diverge
-from client to client, and cannot be relied-upon to provide a hard security boundary. Specifications
-which ignore this advice are encouraged to carefully consider whether URLs' schemes ought to be
-incorporated into any decision made based upon whether or not two <a for=/>hosts</a> are
-<a>same site</a>. HTML's <a>same origin-domain</a> concept is a reasonable example of this
-consideration in practice.
+<p class=warning>Specifications should prefer the <a for=/>origin</a> concept for security
+decisions. The notion of "<a for=host>public suffix</a>","<a for=host>registrable domain</a>",
+and "<a>same site</a>" cannot be relied-upon to provide a hard security boundary, as the public
+suffix list will diverge from client to client. Specifications which ignore this advice are
+encouraged to carefully consider whether URLs' schemes ought to be incorporated into any decision
+made based upon whether or not two <a for=/>hosts</a> are <a>same site</a>. HTML's <a>same
+origin-domain</a> concept is a reasonable example of this consideration in practice.
 
 
 <h3 id=idna>IDNA</h3>

--- a/url.bs
+++ b/url.bs
@@ -383,7 +383,7 @@ obtain <var>host</var>'s <a for=host>registrable domain</a>, run these steps:
 </div>
 
 <p class=warning>Specifications should prefer the <a for=/>origin</a> concept for security
-decisions. The notion of "<a for=host>public suffix</a>","<a for=host>registrable domain</a>",
+decisions. The notion of "<a for=host>public suffix</a>", "<a for=host>registrable domain</a>",
 and "<a>same site</a>" cannot be relied-upon to provide a hard security boundary, as the public
 suffix list will diverge from client to client. Specifications which ignore this advice are
 encouraged to carefully consider whether URLs' schemes ought to be incorporated into any decision


### PR DESCRIPTION
This is my first attempt at fixing #429.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/430.html" title="Last updated on Feb 11, 2019, 1:15 PM UTC (046ebf1)">Preview</a> | <a href="https://whatpr.org/url/430/d2ef633...046ebf1.html" title="Last updated on Feb 11, 2019, 1:15 PM UTC (046ebf1)">Diff</a>