### PR TITLE
Remove gopher's case from origin's algorithm

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2444,7 +2444,6 @@ background information. [[!HTML]]
   (<code>https</code>, <code>whatwg.org</code>, null, null).
 
  <dt>"<code>ftp</code>"
- <dt>"<code>gopher</code>"
  <dt>"<code>http</code>"
  <dt>"<code>https</code>"
  <dt>"<code>ws</code>"


### PR DESCRIPTION
After #453 the "gopher:" is not special anymore.
According to https://github.com/web-platform-tests/wpt/pull/19770 an intention is that gopher's URL's origin would be opaque (null).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/454.html" title="Last updated on Oct 18, 2019, 5:25 PM UTC (15c823b)">Preview</a> | <a href="https://whatpr.org/url/454/d589670...15c823b.html" title="Last updated on Oct 18, 2019, 5:25 PM UTC (15c823b)">Diff</a>