### PR TITLE
Forbid < and > in hosts

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -274,8 +274,8 @@ for further processing.
 <h3 id=host-miscellaneous>Host miscellaneous</h3>
 
 <p>A <dfn export>forbidden host code point</dfn> is U+0000 NULL, U+0009 TAB, U+000A LF, U+000D CR,
-U+0020 SPACE, U+0023 (#), U+0025 (%), U+002F (/), U+003A (:), U+003F (?), U+0040 (@), U+005B ([),
-U+005C (\), or U+005D (]).
+U+0020 SPACE, U+0023 (#), U+0025 (%), U+002F (/), U+003A (:), U+003C (<), or U+003E (>), U+003F (?),
+U+0040 (@), U+005B ([), U+005C (\), or U+005D (]).
 
 <p>A <a for=/>host</a>'s <dfn for=host export>public suffix</dfn> is the portion of a
 <a for=/>host</a> which is included on the <cite>Public Suffix List</cite>. To obtain

--- a/url.bs
+++ b/url.bs
@@ -3313,7 +3313,8 @@ Trevor Rowbotham,
 Valentin Gosu,
 Vyacheslav Matva,
 Wei Wang,
-山岸和利 (Yamagishi Kazutoshi), and
+山岸和利 (Yamagishi Kazutoshi),
+Yongsheng Zhang, and
 成瀬ゆい (Yui Naruse)
 for being awesome!
 

--- a/url.bs
+++ b/url.bs
@@ -274,8 +274,8 @@ for further processing.
 <h3 id=host-miscellaneous>Host miscellaneous</h3>
 
 <p>A <dfn export>forbidden host code point</dfn> is U+0000 NULL, U+0009 TAB, U+000A LF, U+000D CR,
-U+0020 SPACE, U+0023 (#), U+0025 (%), U+002F (/), U+003A (:), U+003C (<), or U+003E (>), U+003F (?),
-U+0040 (@), U+005B ([), U+005C (\), or U+005D (]).
+U+0020 SPACE, U+0023 (#), U+0025 (%), U+002F (/), U+003A (:), U+003C (<), U+003E (>), U+003F (?),
+U+0040 (@), U+005B ([), U+005C (\), U+005D (]), or U+005E (^).
 
 <p>A <a for=/>host</a>'s <dfn for=host export>public suffix</dfn> is the portion of a
 <a for=/>host</a> which is included on the <cite>Public Suffix List</cite>. To obtain

--- a/url.bs
+++ b/url.bs
@@ -274,7 +274,7 @@ for further processing.
 <h3 id=host-miscellaneous>Host miscellaneous</h3>
 
 <p>A <dfn export>forbidden host code point</dfn> is U+0000 NULL, U+0009 TAB, U+000A LF, U+000D CR,
-U+0020 SPACE, U+0023 (#), U+0025 (%), U+002F (/), U+003A (:), U+003C (<), U+003E (>), U+003F (?),
+U+0020 SPACE, U+0023 (#), U+0025 (%), U+002F (/), U+003A (:), U+003C (&lt;), U+003E (>), U+003F (?),
 U+0040 (@), U+005B ([), U+005C (\), U+005D (]), or U+005E (^).
 
 <p>A <a for=/>host</a>'s <dfn for=host export>public suffix</dfn> is the portion of a


### PR DESCRIPTION
> Considering <> seem to be forbidden in two browsers, we should consider making them forbidden too. The list is testable through new URL('http://</').href.

This PR add `<` and `>` to `Host miscellaneous`, Close #458


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/459.html" title="Last updated on May 7, 2020, 5:04 PM UTC (605aa0f)">Preview</a> | <a href="https://whatpr.org/url/459/3703f92...605aa0f.html" title="Last updated on May 7, 2020, 5:04 PM UTC (605aa0f)">Diff</a>