### PR TITLE
Correct and add to PSL examples

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -311,7 +311,7 @@ obtain <var>host</var>'s <a for=host>registrable domain</a>, run these steps:
   <tr>
    <td><code>com</code>
    <td><code>com</code>
-   <td><i>null</i>
+   <td>null
   <tr>
    <td><code>example.com</code>
    <td><code>com</code>
@@ -331,23 +331,27 @@ obtain <var>host</var>'s <a for=host>registrable domain</a>, run these steps:
   <tr>
    <td><code>github.io</code>
    <td><code>github.io</code>
-   <td><i>null</i>
+   <td>null
   <tr>
    <td><code>whatwg.github.io</code>
    <td><code>github.io</code>
    <td><code>whatwg.github.io</code>
   <tr>
    <td><code>إختبار</code>
-   <td><code>xn-kgbechtv</code>
-   <td><i>null</i>
+   <td><code>xn--kgbechtv</code>
+   <td>null
   <tr>
    <td><code>example.إختبار</code>
-   <td><code>xn-kgbechtv</code>
-   <td><code>example.xn-kgbechtv</code>
+   <td><code>xn--kgbechtv</code>
+   <td><code>example.xn--kgbechtv</code>
   <tr>
    <td><code>sub.example.إختبار</code>
-   <td><code>xn-kgbechtv</code>
-   <td><code>example.xn-kgbechtv</code>
+   <td><code>xn--kgbechtv</code>
+   <td><code>example.xn--kgbechtv</code>
+  <td>
+   <td><code>[2001:0db8:85a3:0000:0000:8a2e:0370:7334]</code>
+   <td>null
+   <td>null
  </table>
 </div>
 

--- a/url.bs
+++ b/url.bs
@@ -348,7 +348,7 @@ obtain <var>host</var>'s <a for=host>registrable domain</a>, run these steps:
    <td><code>sub.example.إختبار</code>
    <td><code>xn--kgbechtv</code>
    <td><code>example.xn--kgbechtv</code>
-  <td>
+  <tr>
    <td><code>[2001:0db8:85a3:0000:0000:8a2e:0370:7334]</code>
    <td>null
    <td>null


### PR DESCRIPTION
The ASCII prefix is xn--, not xn-. Also add an example where the public suffix is null as callers used to forget about it.

Closes #471.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/472.html" title="Last updated on Mar 27, 2020, 5:50 AM UTC (07b0ed7)">Preview</a> | <a href="https://whatpr.org/url/472/0ce82da...07b0ed7.html" title="Last updated on Mar 27, 2020, 5:50 AM UTC (07b0ed7)">Diff</a>