### PR TITLE
Clarify double-dot path segment parsing

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2110,7 +2110,8 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
           U+005C (\), <a for=list>append</a> the empty string to <var>url</var>'s
           <a for=url>path</a>.
 
-          <p class="note no-backref">Usually <a>c</a> is U+002F (/) at this point.
+          <p class="note no-backref">This means that for input <code>/usr/..</code> the result is
+          <code>/</code> and not a lack of a path.
         </ol>
 
        <li><p>Otherwise, if <var>buffer</var> is a <a>single-dot path segment</a> and if neither

--- a/url.bs
+++ b/url.bs
@@ -2099,10 +2099,19 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
        <li><p>If <var>url</var> <a>is special</a> and <a>c</a> is U+005C (\),
        <a>validation error</a>.
 
-       <li><p>If <var>buffer</var> is a <a>double-dot path segment</a>, <a>shorten</a>
-       <var>url</var>'s <a for=url>path</a>, and then if neither <a>c</a> is U+002F (/), nor
-       <var>url</var> <a>is special</a> and <a>c</a> is U+005C (\), <a for=list>append</a>
-       the empty string to <var>url</var>'s <a for=url>path</a>.
+       <li>
+        <p>If <var>buffer</var> is a <a>double-dot path segment</a>, then:
+
+        <ol>
+         <li><p><a>Shorten</a> <var>url</var>'s <a for=url>path</a>.
+
+         <li>
+          <p>If neither <a>c</a> is U+002F (/), nor <var>url</var> <a>is special</a> and <a>c</a> is
+          U+005C (\), <a for=list>append</a> the empty string to <var>url</var>'s
+          <a for=url>path</a>.
+
+          <p class="note no-backref">Usually <a>c</a> is U+002F (/) at this point.
+        </ol>
 
        <li><p>Otherwise, if <var>buffer</var> is a <a>single-dot path segment</a> and if neither
        <a>c</a> is U+002F (/), nor <var>url</var> <a>is special</a> and <a>c</a> is U+005C (\),


### PR DESCRIPTION
Fixes #295.

@GPHemsley @Hixie, what do you think?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/482.html" title="Last updated on Apr 28, 2020, 6:17 AM UTC (3f408d6)">Preview</a> | <a href="https://whatpr.org/url/482/980ba89...3f408d6.html" title="Last updated on Apr 28, 2020, 6:17 AM UTC (3f408d6)">Diff</a>