### PR TITLE
Clarify output of PSL is in A-Labels

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -288,7 +288,7 @@ U+005C (\), or U+005D (]).
  <a href="https://publicsuffix.org/list/">Public Suffix List algorithm</a> with <var>host</var> as
  domain. [[!PSL]]
 
- <li><p>Assert: <var>publicSuffix</var> contains only <a>ASCII code points</a>.
+ <li><p>Assert: <var>publicSuffix</var> is an <a>ASCII string</a>.
 
  <li><p>Return <var>publicSuffix</var>.
 </ol>
@@ -305,7 +305,7 @@ obtain <var>host</var>'s <a for=host>registrable domain</a>, run these steps:
  <a href="https://publicsuffix.org/list/">Public Suffix List algorithm</a> with <var>host</var> as
  domain. [[!PSL]]
 
- <li><p>Assert: <var>registrableDomain</var> contains only <a>ASCII code points</a>.
+ <li><p>Assert: <var>registrableDomain</var> is an <a>ASCII string</a>.
 
  <li><p>Return <var>registrableDomain</var>.
 </ol>

--- a/url.bs
+++ b/url.bs
@@ -284,9 +284,11 @@ U+005C (\), or U+005D (]).
 <ol>
  <li><p>If <var>host</var> is not a <a>domain</a>, then return null.
 
- <li><p>Return the <a for=host>public suffix</a> obtained by executing the
- <a href="https://publicsuffix.org/list/">algorithm</a> defined by the Public Suffix List on
- <var>host</var>. [[!PSL]].
+ <li><p>Let <var>publicSuffix</var> be the public suffix determined by running the
+ <a href="https://publicsuffix.org/list/">Public Suffix List algorithm</a> with <var>host</var> as
+ domain. [[!PSL]]
+
+ <li><p>Return <var>publicSuffix</var> encoded using A-Labels. [[!UTS46]]
 </ol>
 
 <p>A <a for=/>host</a>'s <dfn for=host export>registrable domain</dfn> is a <a>domain</a> formed by
@@ -297,9 +299,11 @@ obtain <var>host</var>'s <a for=host>registrable domain</a>, run these steps:
  <li><p>If <var>host</var>'s <a for=host>public suffix</a> is null or <var>host</var>'s
  <a for=host>public suffix</a> <a for=host>equals</a> <var>host</var>, then return null.
 
- <li><p>Return the <a for=host>registrable domain</a> obtained by executing the
- <a href="https://publicsuffix.org/list/">algorithm</a> defined by the Public Suffix List on
- <var>host</var>. [[!PSL]]
+ <li><p>Let <var>registrableDomain</var> be the registrable domain determined by running the
+ <a href="https://publicsuffix.org/list/">Public Suffix List algorithm</a> with <var>host</var> as
+ domain. [[!PSL]]
+
+ <li><p>Return <var>registrableDomain</var> encoded using A-Labels. [[!UTS46]]
 </ol>
 
 <div class=example id=example-host-psl>

--- a/url.bs
+++ b/url.bs
@@ -288,7 +288,7 @@ U+005C (\), or U+005D (]).
  <a href="https://publicsuffix.org/list/">Public Suffix List algorithm</a> with <var>host</var> as
  domain. [[!PSL]]
 
- <li><p>Assert: <var>publicSuffix</var> is encoded using A-Labels. [[!UTS46]]
+ <li><p>Assert: <var>publicSuffix</var> contains only <a>ASCII code points</a>.
 
  <li><p>Return <var>publicSuffix</var>.
 </ol>
@@ -305,7 +305,7 @@ obtain <var>host</var>'s <a for=host>registrable domain</a>, run these steps:
  <a href="https://publicsuffix.org/list/">Public Suffix List algorithm</a> with <var>host</var> as
  domain. [[!PSL]]
 
- <li><p>Assert: <var>registrableDomain</var> is encoded using A-Labels. [[!UTS46]]
+ <li><p>Assert: <var>registrableDomain</var> contains only <a>ASCII code points</a>.
 
  <li><p>Return <var>registrableDomain</var>.
 </ol>

--- a/url.bs
+++ b/url.bs
@@ -288,7 +288,9 @@ U+005C (\), or U+005D (]).
  <a href="https://publicsuffix.org/list/">Public Suffix List algorithm</a> with <var>host</var> as
  domain. [[!PSL]]
 
- <li><p>Return <var>publicSuffix</var> encoded using A-Labels. [[!UTS46]]
+ <li><p>Assert: <var>publicSuffix</var> is encoded using A-Labels. [[!UTS46]]
+
+ <li><p>Return <var>publicSuffix</var>.
 </ol>
 
 <p>A <a for=/>host</a>'s <dfn for=host export>registrable domain</dfn> is a <a>domain</a> formed by
@@ -303,7 +305,9 @@ obtain <var>host</var>'s <a for=host>registrable domain</a>, run these steps:
  <a href="https://publicsuffix.org/list/">Public Suffix List algorithm</a> with <var>host</var> as
  domain. [[!PSL]]
 
- <li><p>Return <var>registrableDomain</var> encoded using A-Labels. [[!UTS46]]
+ <li><p>Assert: <var>registrableDomain</var> is encoded using A-Labels. [[!UTS46]]
+
+ <li><p>Return <var>registrableDomain</var>.
 </ol>
 
 <div class=example id=example-host-psl>


### PR DESCRIPTION
Closes #396.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/484.html" title="Last updated on Apr 26, 2020, 3:58 PM UTC (695c968)">Preview</a> | <a href="https://whatpr.org/url/484/980ba89...695c968.html" title="Last updated on Apr 26, 2020, 3:58 PM UTC (695c968)">Diff</a>