### PR TITLE
Remove U+0000 case in the fragment state

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2256,16 +2256,10 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
 
    <dt><dfn>fragment state</dfn>
    <dd>
-    <p>Switching on <a>c</a>:
-    <dl class=switch>
-     <dt>The <a>EOF code point</a>
-     <dd><p>Do nothing.
+    <ol>
+     <li>
+      <p>If <a>c</a> is not the <a>EOF code point</a>, then:
 
-     <dt>U+0000 NULL
-     <dd><p><a>Validation error</a>.
-
-     <dt>Otherwise
-     <dd>
       <ol>
        <li><p>If <a>c</a> is not a <a>URL code point</a> and not U+0025 (%),
        <a>validation error</a>.
@@ -2273,10 +2267,10 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
        <li><p>If <a>c</a> is U+0025 (%) and <a>remaining</a> does not start with two
        <a>ASCII hex digits</a>, <a>validation error</a>.
 
-       <li><p><a>UTF-8 percent encode</a> <a>c</a> using the <a>fragment percent-encode set</a>
-       and append the result to <var>url</var>'s <a for=url>fragment</a>.
+       <li><p><a>UTF-8 percent encode</a> <a>c</a> using the <a>fragment percent-encode set</a> and
+       append the result to <var>url</var>'s <a for=url>fragment</a>.
       </ol>
-    </dl>
+    </ol>
   </dl>
 
  <li><p>Return <var>url</var>.


### PR DESCRIPTION
Tests: ...

Fixes #440.

(Note that I think we should make all states an explicit ordered list for clarity. Because of that I added it here, despite it only containing one step.)

<!--
Thank you for contributing to the URL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
   * Safari
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/23256
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1075492
   * Firefox: (probably not needed, but need tests to confirm)
   * Safari: (probably not needed, but need tests to confirm)

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/486.html" title="Last updated on Apr 27, 2020, 9:40 AM UTC (5d63a5c)">Preview</a> | <a href="https://whatpr.org/url/486/980ba89...5d63a5c.html" title="Last updated on Apr 27, 2020, 9:40 AM UTC (5d63a5c)">Diff</a>