### PR TITLE
Clarify how URL strings map to URL components via table

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1114,6 +1114,50 @@ refers to as well as its origin. It is important that these are cached as the <a
 be removed from the <a>blob URL store</a> between parsing and fetching, while fetching will still
 need to succeed.
 
+<div class=example id=example-url-components>
+ <p>The following table lists how <a>valid URL strings</a>, when <a lt="URL parser">parsed</a>, map
+ to a <a for=/>URL</a>'s components. Username and password are left as exercise for the reader.
+
+ <table>
+  <tr>
+   <th>Input
+   <th>Scheme
+   <th>Host
+   <th>Port
+   <th>Path
+   <th>Query
+   <th>Fragment
+   <th>Cannot-be-base-URL flag
+  <tr>
+   <td><code>https://example.com/</code>
+   <td>"<code>https</code>"
+   <td>"<code>example.com</code>"
+   <td>null
+   <td>« the empty string »
+   <td>null
+   <td>null
+   <td>unset
+  <tr>
+   <td><code>https://localhost:8000/search?q=text#hello</code>
+   <td>"<code>https</code>"
+   <td>"<code>localhost</code>"
+   <td>8000
+   <td>« "<code>search</code>" »
+   <td>"<code>q=text</code>"
+   <td>"<code>hello</code>"
+   <td>unset
+  <tr>
+   <td><code>urn:isbn:9780307476463</code>
+   <td>"<code>urn</code>"
+   <td>null
+   <td>null
+   <td>« "<code>isbn:9780307476463</code>" »
+   <td>null
+   <td>null
+   <td>set
+ </table>
+</div>
+
 
 <h3 id=url-miscellaneous>URL miscellaneous</h3>
 

--- a/url.bs
+++ b/url.bs
@@ -1116,18 +1116,20 @@ need to succeed.
 
 <div class=example id=example-url-components>
  <p>The following table lists how <a>valid URL strings</a>, when <a lt="URL parser">parsed</a>, map
- to a <a for=/>URL</a>'s components. Username and password are left as exercise for the reader.
+ to a <a for=/>URL</a>'s components. <a for=url>Username</a>, <a for=url>password</a>, and
+ <a for=url>blob URL entry</a> are omitted; in the examples below they are the empty string, the
+ empty string, and null, respectively.
 
  <table>
   <tr>
    <th>Input
-   <th>Scheme
-   <th>Host
-   <th>Port
-   <th>Path
-   <th>Query
-   <th>Fragment
-   <th>Cannot-be-base-URL flag
+   <th><a for=url>Scheme</a>
+   <th><a for=url>Host</a>
+   <th><a for=url>Port</a>
+   <th><a for=url>Path</a>
+   <th><a for=url>Query</a>
+   <th><a for=url>Fragment</a>
+   <th><a for=url>Cannot-be-a-base-URL flag</a>
   <tr>
    <td><code>https://example.com/</code>
    <td>"<code>https</code>"
@@ -1155,6 +1157,15 @@ need to succeed.
    <td>null
    <td>null
    <td>set
+  <tr>
+   <td><code>file:///ada/Analytical%20Engine/README.md
+   <td>"<code>file</code>"
+   <td>null
+   <td>null
+   <td>« "<code>ada</code>", "<code>Analytical%20Engine</code>", "<code>README.md</code>" »
+   <td>null
+   <td>null
+   <td>unset
  </table>
 </div>
 


### PR DESCRIPTION
Helps with #337.

Next is taking @TimothyGu's work and give the API a similar table...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/489.html" title="Last updated on May 5, 2020, 8:08 AM UTC (4e48520)">Preview</a> | <a href="https://whatpr.org/url/489/d8fb1a4...4e48520.html" title="Last updated on May 5, 2020, 8:08 AM UTC (4e48520)">Diff</a>