### PR TITLE
Fix validity for opaque hosts

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -457,9 +457,12 @@ up to three <a>ASCII digits</a> per sequence, each representing a decimal number
 
      XXX should we define the format inline instead just like STD 66? -->
 
-<p>A <dfn export>valid opaque-host string</dfn> must be one or more <a>URL units</a>, excluding
-<a>forbidden host code points</a>, or: U+005B ([), followed by a <a>valid IPv6-address string</a>,
-followed by U+005D (]).
+<p>A <dfn export>valid opaque-host string</dfn> must be one of the following:
+
+<ul class=brief>
+ <li><p>one or more <a>URL units</a> excluding <a>forbidden host code points</a>
+ <li><p>U+005B ([), followed by a <a>valid IPv6-address string</a>, followed by U+005D (]).
+</ul>
 
 <p class="note no-backref">This is not part of the definition of <a>valid host string</a> as it
 requires context to be distinguished.
@@ -788,7 +791,7 @@ then runs these steps:
 <var>input</var>, and then runs these steps:
 
 <ol>
- <li><p>If <var>input</var> contains a <a>forbidden host code point</a>, excluding U+0025 (%),
+ <li><p>If <var>input</var> contains a <a>forbidden host code point</a> excluding U+0025 (%),
  <a>validation error</a>, return failure.
 
  <li><p>If <var>input</var> contains a <a>code point</a> that is not a <a>URL code point</a> and not
@@ -1233,7 +1236,7 @@ if all of the following are true:
 <dfn export oldids=syntax-url-absolute-with-fragment>absolute-URL-with-fragment string</dfn> must be
 an <a>absolute-URL string</a>, optionally followed by U+0023 (#) and a <a>URL-fragment string</a>.
 
-<p>An <dfn export oldids=syntax-url-absolute>absolute-URL string</dfn> must be one of the following
+<p>An <dfn export oldids=syntax-url-absolute>absolute-URL string</dfn> must be one of the following:
 
 <ul class=brief>
  <li><p>a <a>URL-scheme string</a> that is an <a>ASCII case-insensitive</a> match for a
@@ -1298,8 +1301,8 @@ followed by a <a>path-absolute-URL string</a>.
 <p>An <dfn export>opaque-host-and-port string</dfn> must be either the empty string or: a
 <a>valid opaque-host string</a>, optionally followed by U+003A (:) and a <a>URL-port string</a>.
 
-<p>A <dfn export oldids=syntax-url-file-scheme-relative>scheme-relative-file-URL string</dfn> must be
-"<code>//</code>", followed by one of the following
+<p>A <dfn export oldids=syntax-url-file-scheme-relative>scheme-relative-file-URL string</dfn> must
+be "<code>//</code>", followed by one of the following:
 
 <ul class=brief>
  <li><p>a <a>valid host string</a>, optionally followed by a
@@ -1324,10 +1327,10 @@ must be a <a>path-relative-URL string</a> that does not start with: a <a>URL-sch
 followed by U+003A (:).
 
 <p>A <dfn export oldids=syntax-url-path-segment>URL-path-segment string</dfn> must be one of the
-following
+following:
 
 <ul class=brief>
- <li><p>zero or more <a>URL units</a>, excluding U+002F (/) and U+003F (?), that together are not a
+ <li><p>zero or more <a>URL units</a> excluding U+002F (/) and U+003F (?), that together are not a
  <a>single-dot path segment</a> or a <a>double-dot path segment</a>.
  <li><p>a <a>single-dot path segment</a>
  <li><p>a <a>double-dot path segment</a>.
@@ -1801,7 +1804,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
       </ol>
 
      <li>
-      <p>Otherwise, if one of the following is true
+      <p>Otherwise, if one of the following is true:
 
       <ul class=brief>
        <li><p><a>c</a> is the <a>EOF code point</a>, U+002F (/), U+003F (?), or U+0023 (#)
@@ -1854,7 +1857,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
       </ol>
 
      <li>
-      <p>Otherwise, if one of the following is true
+      <p>Otherwise, if one of the following is true:
 
       <ul class=brief>
        <li><p><a>c</a> is the <a>EOF code point</a>, U+002F (/), U+003F (?), or U+0023 (#)
@@ -1903,7 +1906,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
      <li><p>If <a>c</a> is an <a>ASCII digit</a>, append <a>c</a> to <var>buffer</var>.
 
      <li>
-      <p>Otherwise, if one of the following is true
+      <p>Otherwise, if one of the following is true:
 
       <ul class=brief>
        <li><p><a>c</a> is the <a>EOF code point</a>, U+002F (/), U+003F (?), or U+0023 (#)
@@ -2127,7 +2130,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
    <dd>
     <ol>
      <li>
-      <p>If one of the following is true
+      <p>If one of the following is true:
 
       <ul class=brief>
        <li><p><a>c</a> is the <a>EOF code point</a> or U+002F (/)
@@ -2240,7 +2243,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
    <dd>
     <ol>
      <li>
-      <p>If <var>encoding</var> is not <a>UTF-8</a> and one of the following is true
+      <p>If <var>encoding</var> is not <a>UTF-8</a> and one of the following is true:
 
       <ul class=brief>
        <li><p><var>url</var> <a>is not special</a>
@@ -2288,7 +2291,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
 
         <ol>
          <li>
-          <p>If one of the following is true
+          <p>If one of the following is true:
 
           <ul class=brief>
            <li><p><var>byte</var> is less than 0x21 (!)

--- a/url.bs
+++ b/url.bs
@@ -457,8 +457,9 @@ up to three <a>ASCII digits</a> per sequence, each representing a decimal number
 
      XXX should we define the format inline instead just like STD 66? -->
 
-<p>A <dfn export>valid opaque-host string</dfn> must be one or more <a>URL units</a> or: U+005B ([),
-followed by a <a>valid IPv6-address string</a>, followed by U+005D (]).
+<p>A <dfn export>valid opaque-host string</dfn> must be one or more <a>URL units</a>, excluding
+<a>forbidden host code points</a>, or: U+005B ([), followed by a <a>valid IPv6-address string</a>,
+followed by U+005D (]).
 
 <p class="note no-backref">This is not part of the definition of <a>valid host string</a> as it
 requires context to be distinguished.
@@ -787,8 +788,14 @@ then runs these steps:
 <var>input</var>, and then runs these steps:
 
 <ol>
- <li><p>If <var>input</var> contains a <a>forbidden host code point</a> excluding U+0025 (%),
+ <li><p>If <var>input</var> contains a <a>forbidden host code point</a>, excluding U+0025 (%),
  <a>validation error</a>, return failure.
+
+ <li><p>If <var>input</var> contains a <a>code point</a> that is not a <a>URL code point</a> and not
+ U+0025 (%), <a>validation error</a>.
+
+ <li><p>If <var>input</var> contains a U+0025 (%) and the two <a>code points</a> following it are
+ not <a>ASCII hex digits</a>, <a>validation error</a>.
 
  <li><p>Let <var>output</var> be the empty string.
 
@@ -3324,6 +3331,7 @@ Kevin Grandon,
 Kornel Lesiński,
 Larry Masinter,
 Leif Halvard Silli,
+Mark Amery,
 Mark Davis,
 Marcos Cáceres,
 Marijn Kruisselbrink,


### PR DESCRIPTION
Closes #437.

(It does strike me that there are some patterns here that might warrant abstraction.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/494.html" title="Last updated on May 5, 2020, 3:41 PM UTC (fd7a344)">Preview</a> | <a href="https://whatpr.org/url/494/1bb45ce...fd7a344.html" title="Last updated on May 5, 2020, 3:41 PM UTC (fd7a344)">Diff</a>