### PR TITLE
Verify domain is not empty after "domain to ASCII"

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -397,6 +397,8 @@ decisions made, i.e. whether to use the <a>same site</a> or <a>schemelessly same
 
  <li><p>If <var>result</var> is a failure value, <a>validation error</a>, return failure.
 
+ <li><p>If <var>result</var> is the empty string, <a>validation error</a>, return failure.
+
  <li><p>Return <var>result</var>.
 </ol>
 
@@ -503,8 +505,6 @@ string <var>input</var> with an optional boolean <var>isNotSpecial</var>, and th
  <a>domain to ASCII</a> on <var>domain</var>.
 
  <li><p>If <var>asciiDomain</var> is failure, <a>validation error</a>, return failure.
-
- <li><p>If <var>asciiDomain</var> is the empty string, <a>validation error</a>, return failure.
 
  <li><p>If <var>asciiDomain</var> contains a <a>forbidden host code point</a>,
  <a>validation error</a>, return failure.

--- a/url.bs
+++ b/url.bs
@@ -504,6 +504,8 @@ string <var>input</var> with an optional boolean <var>isNotSpecial</var>, and th
 
  <li><p>If <var>asciiDomain</var> is failure, <a>validation error</a>, return failure.
 
+ <li><p>If <var>asciiDomain</var> is the empty string, <a>validation error</a>, return failure.
+
  <li><p>If <var>asciiDomain</var> contains a <a>forbidden host code point</a>,
  <a>validation error</a>, return failure.
 


### PR DESCRIPTION
The empty host is not allowed in special non-"file" URLs, but
`domain to ASCII` result can be the empty string, even if the
input is not empty, for example:

* the input consists entirely of IDNA ignored code points;
* the input is `xn--`.

The `domain to ASCII` do not fail when it is called from `host parser`,
because `VerifyDnsLength` is false.
So we need additional check after it.

An interesting case is with file URLS, as empty host is allowed. But most
browsers report failure as well. I tested URLs with the `U+00AD`
percent encoded in host:

| URL               | Chrome    | Firefox     | Safari    |
|-------------------|-----------|-------------|-----------|
| `file://%C2%AD/p` | TypeError | `file:///p` | TypeError |
| `http://%C2%AD/p` | TypeError | TypeError   | TypeError |

Note. To find more IDNA ignored code points refer to IDNA Mapping Table:
https://unicode.org/reports/tr46/#IDNA_Mapping_Table

<!--
Thank you for contributing to the URL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/23432
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/497.html" title="Last updated on May 6, 2020, 6:24 PM UTC (62c5129)">Preview</a> | <a href="https://whatpr.org/url/497/5d17e7f...62c5129.html" title="Last updated on May 6, 2020, 6:24 PM UTC (62c5129)">Diff</a>