### PR TITLE
Named validation errors

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -100,28 +100,15 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
   <tr>
    <td><dfn id=validation-error-domain-to-ascii>domain-to-ASCII</dfn>
    <td>
-    <p>The result of <a abstract-op lt=ToASCII>Unicode ToASCII</a> records an error while processing
-    the input domain.
-    <p class=note>[[!UTS46]] conformance does not require the reporting of precise errors, only that
-    an error has occurred. If the [[!UTS46]] implementation reports precise error codes, user agents
-    are encouraged pass those codes along.
-   <td>Yes
-  <tr>
-   <td><dfn>domain-to-ASCII-empty</dfn>
-   <td>
-    <p>The result of <a abstract-op lt=ToASCII>Unicode ToASCII</a> returns an empty string. This
-    could have been caused by:
-    <ul>
-     <li>Input consists of all ignorable code points.
-     <li>Input is the string "<code>xn--</code>".
-     <li>Input is the empty string and the <i>VerifyDnsLength</i> parameter is false.
-    </ul>
+    <p><a abstract-op lt=ToASCII>Unicode ToASCII</a> records an error or returns the empty string.
+    [[UTS46]]
+    <p class=note>If details about <a abstract-op lt=ToASCII>Unicode ToASCII</a> errors are
+    recorded, user agents are encouraged to pass those along.
    <td>Yes
   <tr>
    <td><dfn>domain-to-Unicode</dfn>
    <td>
-    <p>The result of <a abstract-op lt=ToUnicode>Unicode ToUnicode</a> returns an error while
-    processing the input domain.
+    <p><a abstract-op lt=ToUnicode>Unicode ToUnicode</a> records an error. [[UTS46]]
     <p class=note>The same considerations as with <a>domain-to-ASCII</a> apply.
    <td>·
  <tbody>
@@ -951,8 +938,8 @@ concepts.
  <li><p>If <var>result</var> is a failure value, <a>domain-to-ASCII</a> <a>validation error</a>,
  return failure.
 
- <li><p>If <var>result</var> is the empty string, <a>domain-to-ASCII-empty</a>
- <a>validation error</a>, return failure.
+ <li><p>If <var>result</var> is the empty string, <a>domain-to-ASCII</a> <a>validation error</a>,
+ return failure.
 
  <li><p>Return <var>result</var>.
 </ol>

--- a/url.bs
+++ b/url.bs
@@ -96,6 +96,179 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
    <th>Failure
  <tbody>
   <tr>
+   <th colspan=3 scope=rowgroup><a href=#idna>IDNA</a>
+  <tr>
+   <td><dfn id=validation-error-domain-to-ascii>domain-to-ASCII</dfn>
+   <td>
+    <p>The result of <a abstract-op lt=ToASCII>Unicode toASCII</a> records an error while processing
+    the input domain.
+    <p class=note>[[!UTS46]] conformance does not require the reporting of precise errors, only that
+    an error has occurred. If the [[!UTS46]] implementation reports precise error codes, user agents
+    are encouraged pass those codes along.
+   <td>✅
+  <tr>
+   <td><dfn>domain-to-ASCII-empty</dfn>
+   <td>
+    <p>The result of <a abstract-op lt=ToASCII>Unicode toASCII</a> returns an empty string. This
+    could have been caused by:
+    <ul>
+     <li>Input consists of all ignorable code points.
+     <li>Input is the string "<code>xn--</code>".
+     <li>Input is the empty string and the <i>VerifyDnsLength</i> parameter is false.
+    </ul>
+   <td>✅
+  <tr>
+   <td><dfn>domain-to-Unicode</dfn>
+   <td>
+    <p>The result of <a abstract-op lt=ToUnicode>Unicode toUnicode</a> returns an error while
+    processing the input domain.
+    <p class=note>The same considerations as with <a>domain-to-ASCII</a> apply.
+   <td>❌
+ <tbody>
+  <tr>
+   <th colspan=3 scope=rowgroup><a href=#host-parsing>Host parsing</a>
+  <!-- host parser -->
+  <tr>
+   <td><dfn>unclosed-IPv6-address</dfn>
+   <td>
+    <p>An IPv6 address is missing the closing U+005D (]).
+    <p class=example id=example-unclosed-ipv6-address>"<code>https://[::1</code>"
+   <td>✅
+  <tr>
+   <td><dfn id=validation-error-forbidden-domain-code-point>forbidden-domain-code-point</dfn>
+   <td>
+    <p>The input's host contains a <a>forbidden domain code point</a>.
+    <div class=example id=example-forbidden-domain-code-point>
+     <p>Hosts are <a for=string>percent-decoded</a> before being processed when the URL
+     <a>is special</a>, which would result in the following host portion becoming
+     "<code>exa#mple.org</code>".
+     <p>"<code>https://exa%23mple.org</code>"
+    </div>
+   <td>✅
+  <!-- IPv4 parser -->
+  <tr>
+   <td><dfn>empty-IPv4-part</dfn>
+   <td>
+    <p>Input to the <a>IPv4 parser</a> ends with a U+002E.
+    <p class=example id=example-empty-ipv4-part>"<code>https://127.0.0.1./</code>"
+   <td>❌
+  <tr>
+   <td><dfn>too-many-IPv4-parts</dfn>
+   <td>
+    <p>An <a for=/>IPv4 address</a> consists of 4 parts.
+    <p class=example id=example-too-many-ipv4-parts>"<code>https://1.2.3.4.5/</code>"
+   <td>✅
+  <tr>
+   <td><dfn>non-numeric-IPv4-part</dfn>
+   <td>
+    <p>An IPv4 part was not numeric.
+    <p class=example id=example-non-numeric-ipv4-part>"<code>https://test.42</code>"
+   <td>✅
+  <tr>
+   <td><dfn>non-decimal-IPv4-part</dfn>
+   <td>
+    <p>The IPv4 address contains numbers expressed using hexadecimal or octal digits.
+    <p class=example id=example-non-decimal-ipv4-part>"<code>https://127.0.0x0.1</code>"
+   <td>❌
+  <tr>
+   <td><dfn>IPv4-part-out-of-range</dfn>
+   <td>
+    <p>An IPv4 part exceeds 255.
+    <p class=example id=example-ipv4-part-out-of-range>"<code>https://255.255.4000.1</code>"
+   <td>✅ (only if applicable to the last IPv4 part)
+  <!-- IPv6 parser -->
+  <tr>
+   <td><dfn>invalid-compressed-IPv6-address</dfn>
+   <td>
+    <p>An IPv6 address begins with improper compression.
+    <p class=example id=example-invalid-compressed-ipv6-address>"<code>https://[:1]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv6-too-many-pieces</dfn>
+   <td>
+    <p>An IPv6 address contains more than 8 pieces.
+    <p class=example id=example-ipv6-too-many-pieces>"<code>https://[1:2:3:4:5:6:7:8:9]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv6-multiple-compression</dfn>
+   <td>
+    <p>An IPv6 address is compressed in more than one spot.
+    <p class=example id=example-ipv6-multiple-compression>"<code>https://[1::1::1]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-empty-part</dfn>
+   <td>
+    <p>An IPv6 address that contains an IPv4 address has an empty part in the IPv4 address.
+    <p class=example id=example-ipv4-in-ipv6-empty-part>"<code>https://[ffff::.0.0.1]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-too-many-pieces</dfn>
+   <td>
+    <p>An IPv6 address contains an IPv4 address and the IPv6 address has more than 6 pieces.
+    <p class=example id=example-ipv4-in-ipv6-too-many-pieces>"<code>https://[1:1:1:1:1:1:1:127.0.0.1]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-too-many-parts</dfn>
+   <td>
+    <p>An IPv6 address contains an IPv4 address and the IPv4 address has more than 4 parts.
+    <p class=example id=example-ipv4-in-ipv6-too-many-parts>"<code>https://[ffff::127.0.0.1.2]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-unexpected-code-point</dfn>
+   <td>
+    <p>An IPv6 address contains an IPv4 address of which a part contain a code point other than an
+    <a>ASCII digits</a> or is the empty string.
+    <p class=example id=example-ipv4-in-ipv6-unexpected-code-point>"<code>https://[ffff::127.0.xyz.1]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-invalid-first-part</dfn>
+   <td>
+    <p>The first part of an IPv4 address that is contained within an IPv6 address is 0.
+    <p class=example id=example-ipv4-in-ipv6-invalid-first-part>"<code>https://[ffff::0.0.0.1]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-part-out-of-range</dfn>
+   <td>
+    <p>An IPv4 address contained within an IPv6 address contains a part that exceeds 255.
+    <p class=example id=example-ipv4-in-ipv6-part-out-of-range>"<code>https://[ffff::127.0.0.4000]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-too-few-parts</dfn>
+   <td>
+    <p>An IPv4 address contained within an IPv6 address does not contain exactly 4 parts.
+    <p class=example id=example-ipv4-in-ipv6-too-few-parts>"<code>https://[ffff::127.0.0]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv6-unexpected-EOF</dfn>
+   <td>
+    <p>An IPv6 address unexpectedly ends.
+    <p class=example id=example-ipv6-unexpected-eof>"<code>https://[1:2:3:]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv6-unexpected-delimiter</dfn>
+   <td>
+    <p>An IPv6 address contains a code point that is neither an <a>ASCII hex digit</a> nor a
+    U+003A (:).
+    <p class=example id=example-ipv6-unexpected-delimiter>"<code>https://[1:2:3!:4]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv6-too-few-pieces</dfn>
+   <td>
+    <p>An uncompressed IPv6 address contains fewer than 8 pieces.
+    <p class=example id=example-ipv6-too-few-pieces>"<code>https://[1:2:3]</code>"
+   <td>✅
+  <!-- opaque-host parser -->
+  <tr>
+   <td><dfn id=validation-error-forbidden-host-code-point>forbidden-host-code-point</dfn>
+   <td>
+    <p>When an <a>opaque host</a> (in a URL that <a>is not special</a>) contains a
+    <a>forbidden host code point</a>.
+   <p class=example id=example-forbidden-host-code-point>"<code>foo://exa[mple.org</code>"
+   <td>✅
+ <tbody>
+  <tr>
+   <th colspan=3 scope=rowgroup><a href=#url-parsing>URL parsing</a>
+  <tr>
    <td><dfn>unexpected-C0-control-or-space</dfn>
    <td>
     <p>The input to the <a>URL parser</a> contains a leading or trailing <a>C0 control or space</a>. The
@@ -224,6 +397,9 @@ let url = new URL("/c:/path/to/file", "file:///c:/");</code></pre>
     <p>The file URL's host is a Windows drive letter.
     <p class=example id=example-unexpected-windows-drive-letter-host>"<code>file://c:</code>"
    <td>❌
+ <tbody>
+  <tr>
+   <th colspan=3 scope=rowgroup>URL parsing and <a>opaque-host parser</a>
   <tr>
    <td><dfn>invalid-URL-code-point</dfn>
    <td>
@@ -238,149 +414,6 @@ let url = new URL("/c:/path/to/file", "file:///c:/");</code></pre>
     <a for=url>path</a>, <a for=url>query</a>, or <a for=url>fragment</a>.
     <p class=example id=example-unescaped-percent-sign>"<code>https://example.org/%s</code>"
    <td>❌
-  <tr>
-   <td><dfn>unclosed-IPv6-address</dfn>
-   <td>
-    <p>An IPv6 address is missing the closing U+005D (]).
-    <p class=example id=example-unclosed-ipv6-address>"<code>https://[::1</code>"
-   <td>✅
-  <tr>
-   <td><dfn id=validation-error-domain-to-ascii>domain-to-ASCII</dfn>
-   <td>
-    <p>The result of <a abstract-op lt=ToASCII>Unicode toASCII</a> records an error while processing
-    the input domain.
-    <p class=note>[[!UTS46]] conformance does not require the reporting of precise errors, only that
-    an error has occurred. If the [[!UTS46]] implementation reports precise error codes, user agents
-    are encouraged pass those codes along.
-   <td>✅
-  <tr>
-   <td><dfn>domain-to-ASCII-empty</dfn>
-   <td>
-    <p>The result of <a abstract-op lt=ToASCII>Unicode toASCII</a> returns an empty string. This
-    could have been caused by:
-    <ul>
-     <li>Input consists of all ignorable code points.
-     <li>Input is the string "<code>xn--</code>".
-     <li>Input is the empty string and the <i>VerifyDnsLength</i> parameter is false.
-    </ul>
-   <td>✅
-  <tr>
-   <td><dfn>domain-to-Unicode</dfn>
-   <td>
-    <p>The result of <a abstract-op lt=ToUnicode>Unicode toUnicode</a> returns an error while
-    processing the input domain.
-    <p class=note>The same considerations as with <a>domain-to-ASCII</a> apply.
-   <td>❌
-  <tr>
-   <td><dfn id=validation-error-forbidden-domain-code-point>forbidden-domain-code-point</dfn>
-   <td>
-    <p>The input's host contains a <a>forbidden domain code point</a>.
-    <div class=example id=example-forbidden-domain-code-point>
-     <p>Hosts are <a for=string>percent-decoded</a> before being processed when the URL
-     <a>is special</a>, which would result in the following host portion becoming
-     "<code>exa#mple.org</code>".
-     <p>"<code>https://exa%23mple.org</code>"
-    </div>
-   <td>✅
-  <tr>
-   <td><dfn>unexpected-non-decimal-number</dfn>
-   <td>
-    <p>The IPv4 address contains numbers expressed using hexadecimal or octal digits.
-    <p class=example id=example-unexpected-non-decimal-number>"<code>https://127.0.0x0.1</code>"
-   <td>❌
-  <tr>
-   <td><dfn>IPv4-part-out-of-range</dfn>
-   <td>
-    <p>An IPv4 part exceeds 255. This is only fatal if the last part exceeds 255.
-    <p class=example id=example-ipv4-part-out-of-range>"<code>https://255.255.4000.1</code>"
-   <td>✅
-  <tr>
-   <td><dfn>invalid-compressed-IPv6-address</dfn>
-   <td>
-    <p>An IPv6 address begins with improper compression.
-    <p class=example id=example-invalid-compressed-ipv6-address>"<code>https://[:1]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv6-too-many-pieces</dfn>
-   <td>
-    <p>An IPv6 address contains more than 8 pieces.
-    <p class=example id=example-ipv6-too-many-pieces>"<code>https://[1:2:3:4:5:6:7:8:9]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv6-multiple-compression</dfn>
-   <td>
-    <p>An IPv6 address is compressed in more than one spot.
-    <p class=example id=example-ipv6-multiple-compression>"<code>https://[1::1::1]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv4-in-IPv6-empty-part</dfn>
-   <td>
-    <p>An IPv6 address that contains an IPv4 address has an empty part in the IPv4 address.
-    <p class=example id=example-ipv4-in-ipv6-empty-part>"<code>https://[ffff::.0.0.1]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv4-in-IPv6-too-many-pieces</dfn>
-   <td>
-    <p>An IPv6 address contains an IPv4 address and the IPv6 address has more than 6 pieces.
-    <p class=example id=example-ipv4-in-ipv6-too-many-pieces>"<code>https://[1:1:1:1:1:1:1:127.0.0.1]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv6-unexpected-eof</dfn>
-   <td>
-    <p>An IPv6 address unexpectedly ends.
-    <p class=example id=example-ipv6-unexpected-eof>"<code>https://[1:2:3:]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv6-unexpected-delimiter</dfn>
-   <td>
-    <p>An IPv6 address contains a code point that is neither an <a>ASCII hex digit</a> nor a
-    U+003A (:).
-    <p class=example id=example-ipv6-unexpected-delimiter>"<code>https://[1:2:3!:4]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv6-too-few-pieces</dfn>
-   <td>
-    <p>An uncompressed IPv6 address contains fewer than 8 pieces.
-    <p class=example id=example-ipv6-too-few-pieces>"<code>https://[1:2:3]</code>"
-   <td>✅
-  <tr>
-   <td><dfn id=validation-error-forbidden-host-code-point>forbidden-host-code-point</dfn>
-   <td>
-    <p>When an <a>opaque host</a> (in a URL that <a>is not special</a>) contains a
-    <a>forbidden host code point</a>.
-   <p class=example id=example-forbidden-host-code-point>"<code>foo://exa[mple.org</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv4-in-IPv6-too-many-parts</dfn>
-   <td>
-    <p>An IPv6 address contains an IPv4 address and the IPv4 address has more than 4 parts.
-    <p class=example id=example-ipv4-in-ipv6-too-many-parts>"<code>https://[ffff::127.0.0.1.2]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv4-in-IPv6-unexpected-code-point</dfn>
-   <td>
-    <p>An IPv6 address contains an IPv4 address of which a part contain a code point other than an
-    <a>ASCII digits</a> or is the empty string.
-    <p class=example id=example-ipv4-in-ipv6-unexpected-code-point>"<code>https://[ffff::127.0.xyz.1]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv4-in-IPv6-invalid-first-part</dfn>
-   <td>
-    <p>The first part of an IPv4 address that is contained within an IPv6 address is 0.
-    <p class=example id=example-ipv4-in-ipv6-invalid-first-part>"<code>https://[ffff::0.0.0.1]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv4-in-IPv6-part-out-of-range</dfn>
-   <td>
-    <p>An IPv4 address contained within an IPv6 address contains a part that exceeds 255.
-    <p class=example id=example-ipv4-in-ipv6-part-out-of-range>"<code>https://[ffff::127.0.0.4000]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv4-in-IPv6-too-few-parts</dfn>
-   <td>
-    <p>An IPv4 address contained within an IPv6 address does not contain exactly 4 parts.
-    <p class=example id=example-ipv4-in-ipv6-too-few-parts>"<code>https://[ffff::127.0.0]</code>"
-   <td>✅
 </table>
 
 
@@ -1127,7 +1160,7 @@ return value of the <a for=/>host parser</a> is an <a for=/>IPv4 address</a>.
   <p>If the last <a for=list>item</a> in <var>parts</var> is the empty string, then:
 
   <ol>
-   <li><p><a>Validation error</a>.
+   <li><p><a>Empty-IPv4-part</a> <a>validation error</a>.
 
    <li><p>If <var>parts</var>'s <a for=list>size</a> is greater than 1, then <a for=list>remove</a>
    the last <a for=list>item</a> from <var>parts</var>.
@@ -1135,8 +1168,8 @@ return value of the <a for=/>host parser</a> is an <a for=/>IPv4 address</a>.
         but if it somehow is this conditional makes sure we can keep going. -->
   </ol>
 
- <li><p>If <var>parts</var>'s <a for=list>size</a> is greater than 4, <a>validation error</a>,
- return failure.
+ <li><p>If <var>parts</var>'s <a for=list>size</a> is greater than 4, <a>too-many-IPv4-parts</a>
+ <a>validation error</a>, return failure.
 
  <li><p>Let <var>numbers</var> be an empty <a for=/>list</a>.
 
@@ -1147,10 +1180,10 @@ return value of the <a for=/>host parser</a> is an <a for=/>IPv4 address</a>.
    <li><p>Let <var>result</var> be the result of <a lt="IPv4 number parser">parsing</a>
    <var>part</var>.
 
-   <li><p>If <var>result</var> is failure, <a>validation error</a>, return failure.
+   <li><p>If <var>result</var> is failure, <a>non-numeric-IPv4-part</a> <a>validation error</a>,
+   return failure.
 
-   <li><p>If <var>result</var>[1] is true, <a>unexpected-non-decimal-number</a>
-   <a>validation error</a>.
+   <li><p>If <var>result</var>[1] is true, <a>non-decimal-IPv4-part</a> <a>validation error</a>.
 
    <li><p><a for=list>Append</a> <var>result</var>[0] to <var>numbers</var>.
   </ol>
@@ -1162,8 +1195,7 @@ return value of the <a for=/>host parser</a> is an <a for=/>IPv4 address</a>.
  return failure.
 
  <li><p>If the last <a for=list>item</a> in <var>numbers</var> is greater than or equal to
- 256<sup>(5 &minus; <var>numbers</var>'s <a for=list>size</a>)</sup>,
- <a>IPv4-part-out-of-range</a> <a>validation error</a>, return failure.
+ 256<sup>(5 &minus; <var>numbers</var>'s <a for=list>size</a>)</sup>, then return failure.
 
  <li><p>Let <var>ipv4</var> be the last <a for=list>item</a> in <var>numbers</var>.
 
@@ -1368,7 +1400,7 @@ actually doing that with the editors of this document first.
     <ol>
      <li><p>Increase <var>pointer</var> by 1.
 
-     <li><p>If <a>c</a> is the <a>EOF code point</a>, <a>IPv6-unexpected-eof</a>
+     <li><p>If <a>c</a> is the <a>EOF code point</a>, <a>IPv6-unexpected-EOF</a>
      <a>validation error</a>, return failure.
     </ol>
 

--- a/url.bs
+++ b/url.bs
@@ -16,6 +16,11 @@ spec: UTS46; urlPrefix: https://www.unicode.org/reports/tr46/
     type: abstract-op; text: ToUnicode; url: #ToUnicode
 </pre>
 
+<style>
+.yesno .yes { background: yellow; }
+.yesno .yes, .yesno .no { text-align: center; }
+</style>
+
 
 
 <h2 id=goals class=no-num>Goals</h2>
@@ -88,12 +93,18 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
  unclear to other developers.
 </div>
 
-<table>
+<table class=yesno>
  <thead>
   <tr>
    <th>Error type
    <th>Error description
    <th>Failure
+ <!-- The rows inside the <tbody>s are generally sorted by first occurrence. However, where logical
+      groupings exist those override that sorting:
+      - domain- and host- stay together
+      - IPv6- stays together
+      - IPv4-in-IPv6- stays together
+ -->
  <tbody>
   <tr>
    <th colspan=3 scope=rowgroup><a href=#idna>IDNA</a>
@@ -104,23 +115,17 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
     [[UTS46]]
     <p class=note>If details about <a abstract-op lt=ToASCII>Unicode ToASCII</a> errors are
     recorded, user agents are encouraged to pass those along.
-   <td>Yes
+   <td class=yes>Yes
   <tr>
    <td><dfn>domain-to-Unicode</dfn>
    <td>
     <p><a abstract-op lt=ToUnicode>Unicode ToUnicode</a> records an error. [[UTS46]]
     <p class=note>The same considerations as with <a>domain-to-ASCII</a> apply.
-   <td>·
+   <td class=no>·
  <tbody>
   <tr>
    <th colspan=3 scope=rowgroup><a href=#host-parsing>Host parsing</a>
   <!-- host parser -->
-  <tr>
-   <td><dfn>IPv6-unclosed</dfn>
-   <td>
-    <p>An <a for=/>IPv6 address</a> is missing the closing U+005D (]).
-    <p class=example id=example-ipv6-unclosed"<code>https://[::1</code>"
-   <td>Yes
   <tr>
    <td><dfn>domain-invalid-code-point</dfn>
    <td>
@@ -128,67 +133,98 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
     <div class=example id=example-domain-invalid-code-point>
      <p>Hosts are <a for=string>percent-decoded</a> before being processed when the URL
      <a>is special</a>, which would result in the following host portion becoming
-     "<code>exa#mple.org</code>".
+     "<code>exa#mple.org</code>" and thus triggering this error.
      <p>"<code>https://exa%23mple.org</code>"
     </div>
-   <td>Yes
+   <td class=yes>Yes
+  <!-- opaque-host parser -->
+  <tr>
+   <td><dfn>host-invalid-code-point</dfn>
+   <td>
+    <p>An <a>opaque host</a> (in a URL that <a>is not special</a>) contains a
+    <a>forbidden host code point</a>.
+    <p class=example id=example-host-invalid-code-point>"<code>foo://exa[mple.org</code>"
+   <td class=yes>Yes
   <!-- IPv4 parser -->
   <tr>
    <td><dfn>IPv4-empty-part</dfn>
    <td>
     <p>An <a for=/>IPv4 address</a> ends with a U+002E (.).
     <p class=example id=example-ipv4-empty-part>"<code>https://127.0.0.1./</code>"
-   <td>·
+   <td class=no>·
   <tr>
    <td><dfn>IPv4-too-many-parts</dfn>
    <td>
-    <p>An <a for=/>IPv4 address</a> has to consist of 4 parts.
+    <p>An <a for=/>IPv4 address</a> does not consist of exactly 4 parts.
     <p class=example id=example-ipv4-too-many-parts>"<code>https://1.2.3.4.5/</code>"
-   <td>Yes
+   <td class=yes>Yes
   <tr>
    <td><dfn>IPv4-non-numeric-part</dfn>
    <td>
-    <p>An <a for=/>IPv4 address</a> part was not numeric.
+    <p>An <a for=/>IPv4 address</a> part is not numeric.
     <p class=example id=example-ipv4-non-numeric-part>"<code>https://test.42</code>"
-   <td>Yes
+   <td class=yes>Yes
   <tr>
    <td><dfn>IPv4-non-decimal-part</dfn>
    <td>
     <p>The <a for=/>IPv4 address</a> contains numbers expressed using hexadecimal or octal digits.
     <p class=example id=example-ipv4-non-decimal-part>"<code>https://127.0.0x0.1</code>"
-   <td>·
+   <td class=no>·
   <tr>
    <td><dfn>IPv4-out-of-range-part</dfn>
    <td>
     <p>An <a for=/>IPv4 address</a> part exceeds 255.
     <p class=example id=example-ipv4-out-of-range-part>"<code>https://255.255.4000.1</code>"
-   <td>Yes (only if applicable to the last part)
+   <td class=yes>Yes (only if applicable to the last part)
+  <!-- host parser, but grouped with IPv6- -->
+  <tr>
+   <td><dfn>IPv6-unclosed</dfn>
+   <td>
+    <p>An <a for=/>IPv6 address</a> is missing the closing U+005D (]).
+    <p class=example id=example-ipv6-unclosed"<code>https://[::1</code>"
+   <td class=yes>Yes
   <!-- IPv6 parser -->
   <tr>
    <td><dfn>IPv6-invalid-compression</dfn>
    <td>
     <p>An <a for=/>IPv6 address</a> begins with improper compression.
     <p class=example id=example-ipv6-invalid-compression>"<code>https://[:1]</code>"
-   <td>Yes
+   <td class=yes>Yes
   <tr>
    <td><dfn>IPv6-too-many-pieces</dfn>
    <td>
     <p>An <a for=/>IPv6 address</a> contains more than 8 pieces.
     <p class=example id=example-ipv6-too-many-pieces>"<code>https://[1:2:3:4:5:6:7:8:9]</code>"
-   <td>Yes
+   <td class=yes>Yes
   <tr>
    <td><dfn>IPv6-multiple-compression</dfn>
    <td>
     <p>An <a for=/>IPv6 address</a> is compressed in more than one spot.
     <p class=example id=example-ipv6-multiple-compression>"<code>https://[1::1::1]</code>"
-   <td>Yes
+   <td class=yes>Yes
+  <tr>
+   <td><dfn>IPv6-invalid-code-point</dfn>
+   <td>
+    <p>An <a for=/>IPv6 address</a> contains a code point that is neither an <a>ASCII hex digit</a>
+    nor a U+003A (:). Or it unexpectedly ends.
+    <div class=example id=example-ipv6-invalid-code-point>
+     <p>"<code>https://[1:2:3!:4]</code>"
+     <p>"<code>https://[1:2:3:]</code>"
+    </div>
+   <td class=yes>Yes
+  <tr>
+   <td><dfn>IPv6-too-few-pieces</dfn>
+   <td>
+    <p>An uncompressed <a for=/>IPv6 address</a> contains fewer than 8 pieces.
+    <p class=example id=example-ipv6-too-few-pieces>"<code>https://[1:2:3]</code>"
+   <td class=yes>Yes
   <tr>
    <td><dfn>IPv4-in-IPv6-too-many-pieces</dfn>
    <td>
     <p>An <a for=/>IPv6 address</a> with <a for=/>IPv4 address</a> syntax: the IPv6 address has more
     than 6 pieces.
     <p class=example id=example-ipv4-in-ipv6-too-many-pieces>"<code>https://[1:1:1:1:1:1:1:127.0.0.1]</code>"
-   <td>Yes
+   <td class=yes>Yes
   <tr>
    <td><dfn>IPv4-in-IPv6-invalid-code-point</dfn>
    <td>
@@ -205,44 +241,20 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
      <p>"<code>https://[ffff::127.00.0.1]</code>"
      <p>"<code>https://[ffff::127.0.0.1.2]</code>"
     </div>
-   <td>Yes
+   <td class=yes>Yes
   <tr>
    <td><dfn>IPv4-in-IPv6-out-of-range-part</dfn>
    <td>
     <p>An <a for=/>IPv6 address</a> with <a for=/>IPv4 address</a> syntax: an IPv4 part exceeds 255.
     <p class=example id=example-ipv4-in-ipv6-out-of-range-part>"<code>https://[ffff::127.0.0.4000]</code>"
-   <td>Yes
+   <td class=yes>Yes
   <tr>
    <td><dfn>IPv4-in-IPv6-too-few-parts</dfn>
    <td>
     <p>An <a for=/>IPv6 address</a> with <a for=/>IPv4 address</a> syntax: an IPv4 address contains
     too few parts.
     <p class=example id=example-ipv4-in-ipv6-too-few-parts>"<code>https://[ffff::127.0.0]</code>"
-   <td>Yes
-  <tr>
-   <td><dfn>IPv6-invalid-code-point</dfn>
-   <td>
-    <p>An <a for=/>IPv6 address</a> contains a code point that is neither an <a>ASCII hex digit</a>
-    nor a U+003A (:). Or it unexpectedly ends.
-    <div class=example id=example-ipv6-invalid-code-point>
-     <p>"<code>https://[1:2:3!:4]</code>"
-     <p>"<code>https://[1:2:3:]</code>"
-    </div>
-   <td>Yes
-  <tr>
-   <td><dfn>IPv6-too-few-pieces</dfn>
-   <td>
-    <p>An uncompressed <a for=/>IPv6 address</a> contains fewer than 8 pieces.
-    <p class=example id=example-ipv6-too-few-pieces>"<code>https://[1:2:3]</code>"
-   <td>Yes
-  <!-- opaque-host parser -->
-  <tr>
-   <td><dfn>host-invalid-code-point</dfn>
-   <td>
-    <p>An <a>opaque host</a> (in a URL that <a>is not special</a>) contains a
-    <a>forbidden host code point</a>.
-    <p class=example id=example-host-invalid-code-point>"<code>foo://exa[mple.org</code>"
-   <td>Yes
+   <td class=yes>Yes
  <tbody>
   <tr>
    <th colspan=3 scope=rowgroup><a href=#url-parsing>URL parsing</a>
@@ -258,7 +270,7 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
      <p>"<code>ht<br>tps://example.org</code>"
      <p>"<code>https://example.org/%s</code>"
     </div>
-   <td>·
+   <td class=no>·
   <tr>
    <td><dfn>special-scheme-missing-following-solidus</dfn>
    <td>
@@ -269,7 +281,7 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
      <pre><code class="lang-javascript">
 const url = new URL("https:foo.html", "https://example.org/");</code></pre>
     </div>
-   <td>·
+   <td class=no>·
   <tr>
    <td><dfn>missing-scheme-non-relative-URL</dfn>
    <td>
@@ -285,13 +297,13 @@ const url = new URL("💩");</code></pre>
      <pre><code class=lang-javascript>
 const url = new URL("💩", "mailto:user@example.org");</code></pre>
     </div>
-   <td>Yes
+   <td class=yes>Yes
   <tr>
    <td><dfn>invalid-reverse-solidus</dfn>
    <td>
     <p>The URL has a <a>special scheme</a> and it uses U+005C (\) instead of U+002F (/).
     <p class=example id=example-invalid-reverse-solidus>"<code>https://example.org\path\to\file</code>"
-   <td>·
+   <td class=no>·
   <tr>
    <td><dfn>invalid-credentials</dfn>
    <td>
@@ -300,7 +312,7 @@ const url = new URL("💩", "mailto:user@example.org");</code></pre>
      <p>"<code>https://user@example.org</code>"
      <p>"<code>https://user:pass@</code>"
     </div>
-   <td>Yes (only if there is no host)
+   <td class=yes>Yes (only if there is no host)
   <tr>
    <td><dfn>host-missing</dfn>
    <td>
@@ -309,19 +321,19 @@ const url = new URL("💩", "mailto:user@example.org");</code></pre>
      <p>"<code>https://#fragment</code>"
      <p>"<code>https://:443</code>"
     </div>
-   <td>·
+   <td class=no>·
   <tr>
    <td><dfn>port-out-of-range</dfn>
    <td>
     <p>The input's port is too big.
     <p class=example id=example-port-out-of-range>"<code>https://example.org:70000</code>"
-   <td>Yes
+   <td class=yes>Yes
   <tr>
    <td><dfn>port-invalid</dfn>
    <td>
     <p>The input's port is invalid.
     <p class=example id=example-port-invalid>"<code>https://example.org:7z</code>"
-   <td>Yes
+   <td class=yes>Yes
   <tr>
    <td><dfn>file-invalid-Windows-drive-letter</dfn>
    <td>
@@ -329,13 +341,13 @@ const url = new URL("💩", "mailto:user@example.org");</code></pre>
     the <a>base URL</a>'s <a for=url>scheme</a> is "<code>file</code>".
     <pre class=example id=example-file-invalid-windows-drive-letter><code class=lang-javascript>
 const url = new URL("/c:/path/to/file", "file:///c:/");</code></pre>
-   <td>·
+   <td class=no>·
   <tr>
    <td><dfn>file-invalid-Windows-drive-letter-host</dfn>
    <td>
     <p>A <code>file:</code> URL's host is a Windows drive letter.
     <p class=example id=example-file-invalid-windows-drive-letter-host>"<code>file://c:</code>"
-   <td>·
+   <td class=no>·
 </table>
 
 

--- a/url.bs
+++ b/url.bs
@@ -118,13 +118,13 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
   <tr>
    <td><dfn>IPv6-unclosed</dfn>
    <td>
-    <p>An IPv6 address is missing the closing U+005D (]).
+    <p>An <a for=/>IPv6 address</a> is missing the closing U+005D (]).
     <p class=example id=example-ipv6-unclosed"<code>https://[::1</code>"
    <td>Yes
   <tr>
    <td><dfn>domain-invalid-code-point</dfn>
    <td>
-    <p>The input's host contains a <a>forbidden domain code point</a>.
+    <p>The input's <a for=/>host</a> contains a <a>forbidden domain code point</a>.
     <div class=example id=example-domain-invalid-code-point>
      <p>Hosts are <a for=string>percent-decoded</a> before being processed when the URL
      <a>is special</a>, which would result in the following host portion becoming
@@ -136,7 +136,7 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
   <tr>
    <td><dfn>IPv4-empty-part</dfn>
    <td>
-    <p>Input to the <a>IPv4 parser</a> ends with a U+002E.
+    <p>An <a for=/>IPv4 address</a> ends with a U+002E (.).
     <p class=example id=example-ipv4-empty-part>"<code>https://127.0.0.1./</code>"
    <td>·
   <tr>

--- a/url.bs
+++ b/url.bs
@@ -17,7 +17,7 @@ spec: UTS46; urlPrefix: https://www.unicode.org/reports/tr46/
 </pre>
 
 <style>
-.yesno .yes { background: yellow; }
+.yesno .yes { background: papayawhip; }
 .yesno .yes, .yesno .no { text-align: center; }
 </style>
 
@@ -103,8 +103,7 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
       groupings exist those override that sorting:
       - domain- and host- stay together
       - IPv6- stays together
-      - IPv4-in-IPv6- stays together
- -->
+      - IPv4-in-IPv6- stays together -->
  <tbody>
   <tr>
    <th colspan=3 scope=rowgroup><a href=#idna>IDNA</a>
@@ -175,7 +174,7 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
    <td>
     <p>An <a for=/>IPv4 address</a> part exceeds 255.
     <p class=example id=example-ipv4-out-of-range-part>"<code>https://255.255.4000.1</code>"
-   <td class=yes>Yes (only if applicable to the last part)
+   <td class=yes>Yes<br>(only if applicable to the last part)
   <!-- host parser, but grouped with IPv6- -->
   <tr>
    <td><dfn>IPv6-unclosed</dfn>
@@ -312,7 +311,7 @@ const url = new URL("💩", "mailto:user@example.org");</code></pre>
      <p>"<code>https://user@example.org</code>"
      <p>"<code>https://user:pass@</code>"
     </div>
-   <td class=yes>Yes (only if there is no host)
+   <td class=yes>Yes<br>(only if there is no host)
   <tr>
    <td><dfn>host-missing</dfn>
    <td>

--- a/url.bs
+++ b/url.bs
@@ -183,13 +183,6 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
     <p class=example id=example-ipv6-multiple-compression>"<code>https://[1::1::1]</code>"
    <td>Yes
   <tr>
-   <td><dfn>IPv4-in-IPv6-empty-part</dfn>
-   <td>
-    <p>An <a for=/>IPv6 address</a> with <a for=/>IPv4 address</a> syntax: an empty part in the
-    IPv4 address.
-    <p class=example id=example-ipv4-in-ipv6-empty-part>"<code>https://[ffff::.0.0.1]</code>"
-   <td>Yes
-  <tr>
    <td><dfn>IPv4-in-IPv6-too-many-pieces</dfn>
    <td>
     <p>An <a for=/>IPv6 address</a> with <a for=/>IPv4 address</a> syntax: the IPv6 address has more
@@ -206,6 +199,7 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
      <li>There are too many IPv4 parts.
     </ul>
     <div class=example id=example-ipv4-in-ipv6-invalid-code-point>
+     <p>"<code>https://[ffff::.0.0.1]</code>"
      <p>"<code>https://[ffff::127.0.xyz.1]</code>"
      <p>"<code>https://[ffff::127.0xyz]</code>"
      <p>"<code>https://[ffff::127.00.0.1]</code>"
@@ -226,17 +220,14 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
     <p class=example id=example-ipv4-in-ipv6-too-few-parts>"<code>https://[ffff::127.0.0]</code>"
    <td>Yes
   <tr>
-   <td><dfn>IPv6-unexpected-EOF</dfn>
-   <td>
-    <p>An <a for=/>IPv6 address</a> unexpectedly ends.
-    <p class=example id=example-ipv6-unexpected-eof>"<code>https://[1:2:3:]</code>"
-   <td>Yes
-  <tr>
    <td><dfn>IPv6-invalid-code-point</dfn>
    <td>
     <p>An <a for=/>IPv6 address</a> contains a code point that is neither an <a>ASCII hex digit</a>
-    nor a U+003A (:).
-    <p class=example id=example-ipv6-invalid-code-point>"<code>https://[1:2:3!:4]</code>"
+    nor a U+003A (:). Or it unexpectedly ends.
+    <div class=example id=example-ipv6-invalid-code-point>
+     <p>"<code>https://[1:2:3!:4]</code>"
+     <p>"<code>https://[1:2:3:]</code>"
+    </div>
    <td>Yes
   <tr>
    <td><dfn>IPv6-too-few-pieces</dfn>
@@ -255,20 +246,29 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
  <tbody>
   <tr>
    <th colspan=3 scope=rowgroup><a href=#url-parsing>URL parsing</a>
+  <!-- invalid-URL-unit is also present in the opaque-host parser, but this is a more logical place.
+       -->
   <tr>
-   <td><dfn>scheme-invalid-code-point</dfn>
+   <td><dfn>invalid-URL-unit</dfn>
    <td>
-    <p>The URL's <a for=url>scheme</a> contains an invalid code point.
-    <div class=example id=example-scheme-invalid-code-point>
-     TODO: actual setter examples as prior examples were wrong
+    <p>A code point is found that is not a <a>URL unit</a>.
+    <div class=example id=example-invalid-url-unit>
+     <p>"<code>https://example.org/></code>"
+     <p>"<code> https://example.org </code>"
+     <p>"<code>ht<br>tps://example.org</code>"
+     <p>"<code>https://example.org/%s</code>"
     </div>
-   <td>Yes
+   <td>·
   <tr>
-   <td><dfn>file-scheme-missing-following-solidus</dfn>
+   <td><dfn>special-scheme-missing-following-solidus</dfn>
    <td>
-    <p>The URL parser encounters a URL with a "<code>file</code>" <a for=url>scheme</a> that is not
-    followed by "<code>//</code>".
-    <p class=example id=example-file-scheme-missing-following-solidus>"<code>file:c:/my-secret-folder</code>"
+    <p>The input's scheme is not followed by "<code>//</code>".
+    <div class=example id=example-special-scheme-missing-following-solidus>
+     <p>"<code>file:c:/my-secret-folder</code>"
+     <p>"<code>https:example.org</code>"
+     <pre><code class="lang-javascript">
+const url = new URL("https:foo.html", "https://example.org/");</code></pre>
+    </div>
    <td>·
   <tr>
    <td><dfn>missing-scheme-non-relative-URL</dfn>
@@ -279,20 +279,13 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
     <div class=example id=example-missing-scheme-non-relative-url>
      <p>Input's <a for=url>scheme</a> is missing and no <a>base URL</a> is given:
      <pre><code class=lang-javascript>
-let url = new URL("💩");</code></pre>
+const url = new URL("💩");</code></pre>
      <p>Input's <a for=url>scheme</a> is missing, but the <a>base URL</a> has an
      <a for=url>opaque path</a>.
      <pre><code class=lang-javascript>
-let url = new URL("💩", "mailto:user@example.org");</code></pre>
+const url = new URL("💩", "mailto:user@example.org");</code></pre>
     </div>
    <td>Yes
-  <tr>
-   <td><dfn>relative-URL-missing-beginning-solidus</dfn>
-   <td>
-    <p>The input is a <a>relative-URL string</a> that does not begin with U+002F (/).
-    <pre class=example id=example-relative-url-missing-beginning-solidus><code class="lang-javascript">
-let url = new URL("foo.html", "https://example.org/");</code></pre>
-   <td>·
   <tr>
    <td><dfn>invalid-reverse-solidus</dfn>
    <td>
@@ -300,32 +293,21 @@ let url = new URL("foo.html", "https://example.org/");</code></pre>
     <p class=example id=example-invalid-reverse-solidus>"<code>https://example.org\path\to\file</code>"
    <td>·
   <tr>
-   <td><dfn>host-missing-solidus</dfn>
-   <td>
-    <p>The URL's <a for=url>host</a> is not preceded by "<code>//</code>".
-    <p class=example id=example-host-missing-solidus>"<code>https:example.org</code>"
-   <td>·
-  <tr>
    <td><dfn>invalid-credentials</dfn>
    <td>
-    <p>The URL <a>includes credentials</a>.
+    <p>The input <a>includes credentials</a>.
     <div class=example id=example-invalid-credentials>
      <p>"<code>https://user@example.org</code>"
      <p>"<code>https://user:pass@</code>"
     </div>
    <td>Yes (only if there is no host)
   <tr>
-   <td><dfn>host-empty</dfn>
+   <td><dfn>host-missing</dfn>
    <td>
-    <p>The URL has a <a>special scheme</a>, but does not contain a <a for=url>host</a>. Or the
-    <a for=url>host</a> portion of the URL is an empty string when it <a>includes credentials</a> or
-    a <a>port</a> and the <a>basic URL parser</a>'s state is overridden.
-    <div class=example id=example-host-empty>
+    <p>The input has a <a>special scheme</a>, but does not contain a <a for=/>host</a>.
+    <div class=example id=example-host-missing>
      <p>"<code>https://#fragment</code>"
      <p>"<code>https://:443</code>"
-     <pre><code class=lang-javascript>
-const url = new URL("https://example:9000");
-url.hostname = "";</code></pre>
     </div>
    <td>·
   <tr>
@@ -346,27 +328,13 @@ url.hostname = "";</code></pre>
     <p>The input is a <a>relative-URL string</a> that <a>starts with a Windows drive letter</a> and
     the <a>base URL</a>'s <a for=url>scheme</a> is "<code>file</code>".
     <pre class=example id=example-file-invalid-windows-drive-letter><code class=lang-javascript>
-let url = new URL("/c:/path/to/file", "file:///c:/");</code></pre>
+const url = new URL("/c:/path/to/file", "file:///c:/");</code></pre>
    <td>·
   <tr>
    <td><dfn>file-invalid-Windows-drive-letter-host</dfn>
    <td>
     <p>A <code>file:</code> URL's host is a Windows drive letter.
     <p class=example id=example-file-invalid-windows-drive-letter-host>"<code>file://c:</code>"
-   <td>·
- <tbody>
-  <tr>
-   <th colspan=3 scope=rowgroup>URL parsing and <a>opaque-host parser</a>
-  <tr>
-   <td><dfn>invalid-URL-unit</dfn>
-   <td>
-    <p>A code point is found that is not a <a>URL unit</a>.
-    <div class=example id=example-invalid-url-unit>
-     <p>"<code>https://example.org/></code>"
-     <p>"<code> https://example.org </code>"
-     <p>"<code>ht<br>tps://example.org</code>"
-     <p>"<code>https://example.org/%s</code>"
-    </div>
    <td>·
 </table>
 
@@ -1283,8 +1251,8 @@ actually doing that with the editors of this document first.
     <p>If <a>c</a> is U+002E (.), then:
 
     <ol>
-     <li><p>If <var>length</var> is 0, <a>IPv4-in-IPv6-empty-part</a> <a>validation error</a>,
-     return failure.
+     <li><p>If <var>length</var> is 0, <a>IPv4-in-IPv6-invalid-code-point</a>
+     <a>validation error</a>, return failure.
 
      <li><p>Decrease <var>pointer</var> by <var>length</var>.
 
@@ -1355,7 +1323,7 @@ actually doing that with the editors of this document first.
     <ol>
      <li><p>Increase <var>pointer</var> by 1.
 
-     <li><p>If <a>c</a> is the <a>EOF code point</a>, <a>IPv6-unexpected-EOF</a>
+     <li><p>If <a>c</a> is the <a>EOF code point</a>, <a>IPv6-invalid-code-point</a>
      <a>validation error</a>, return failure.
     </ol>
 
@@ -2188,7 +2156,8 @@ and then runs these steps:
      <a>no scheme state</a> and decrease <var>pointer</var> by 1.
 
      <li>
-      <p>Otherwise, <a>scheme-invalid-code-point</a> <a>validation error</a>, return failure.
+      <p>Otherwise, return failure.
+      <!-- API validation error -->
 
       <p class=note>This indication of failure is used exclusively by the {{Location}} object's
       {{Location/protocol}} setter.
@@ -2240,7 +2209,7 @@ and then runs these steps:
 
         <ol>
          <li><p>If <a>remaining</a> does not start with "<code>//</code>",
-         <a>file-scheme-missing-following-solidus</a> <a>validation error</a>.
+         <a>special-scheme-missing-following-solidus</a> <a>validation error</a>.
 
          <li><p>Set <var>state</var> to <a>file state</a>.
         </ol>
@@ -2272,7 +2241,8 @@ and then runs these steps:
      in <var>input</var>).
 
      <li>
-      <p>Otherwise, <a>scheme-invalid-code-point</a> <a>validation error</a>, return failure.
+      <p>Otherwise, return failure.
+      <!-- API validation error -->
 
       <p class=note>This indication of failure is used exclusively by the {{Location}} object's
       {{Location/protocol}} setter. Furthermore, the non-failure termination earlier in this state
@@ -2310,7 +2280,7 @@ and then runs these steps:
      <var>state</var> to <a>special authority ignore slashes state</a> and increase
      <var>pointer</var> by 1.
 
-     <li><p>Otherwise, <a>relative-URL-missing-beginning-solidus</a> <a>validation error</a>, set
+     <li><p>Otherwise, <a>special-scheme-missing-following-solidus</a> <a>validation error</a>, set
      <var>state</var> to <a>relative state</a> and decrease <var>pointer</var> by 1.
     </ol>
 
@@ -2407,8 +2377,9 @@ and then runs these steps:
      <var>state</var> to <a>special authority ignore slashes state</a> and increase
      <var>pointer</var> by 1.
 
-     <li><p>Otherwise, <a>host-missing-solidus</a> <a>validation error</a>, set <var>state</var> to
-     <a>special authority ignore slashes state</a> and decrease <var>pointer</var> by 1.
+     <li><p>Otherwise, <a>special-scheme-missing-following-solidus</a> <a>validation error</a>, set
+     <var>state</var> to <a>special authority ignore slashes state</a> and decrease
+     <var>pointer</var> by 1.
     </ol>
 
    <dt><dfn export for="basic URL parser" id=special-authority-ignore-slashes-state>special authority ignore slashes state</dfn>
@@ -2417,7 +2388,7 @@ and then runs these steps:
      <li><p>If <a>c</a> is neither U+002F (/) nor U+005C (\), then set <var>state</var> to
      <a>authority state</a> and decrease <var>pointer</var> by 1.
 
-     <li><p>Otherwise, <a>host-missing-solidus</a> <a>validation error</a>.
+     <li><p>Otherwise, <a>special-scheme-missing-following-solidus</a> <a>validation error</a>.
     </ol>
 
    <dt><dfn export for="basic URL parser" id=authority-state>authority state</dfn>
@@ -2492,7 +2463,7 @@ and then runs these steps:
       <p>Otherwise, if <a>c</a> is U+003A (:) and <var>insideBrackets</var> is false, then:
 
       <ol>
-       <li><p>If <var>buffer</var> is the empty string, <a>host-empty</a> <a>validation error</a>,
+       <li><p>If <var>buffer</var> is the empty string, <a>host-missing</a> <a>validation error</a>,
        return failure.
        <!-- No URLs with port, but without host. -->
 
@@ -2521,13 +2492,14 @@ and then runs these steps:
 
       <ol>
        <li><p>If <var>url</var> <a>is special</a> and <var>buffer</var> is the empty string,
-       <a>host-empty</a> <a>validation error</a>, return failure.
+       <a>host-missing</a> <a>validation error</a>, return failure.
        <!-- http://? -> failure
             test://? -> test://? -->
 
        <li><p>Otherwise, if <var>state override</var> is given, <var>buffer</var> is the empty
        string, and either <var>url</var> <a>includes credentials</a> or <var>url</var>'s
-       <a for=url>port</a> is non-null, <a>host-empty</a> <a>validation error</a>, return.
+       <a for=url>port</a> is non-null, return.
+       <!-- API validation error -->
 
        <li><p>Let <var>host</var> be the result of <a>host parsing</a> <var>buffer</var> with
        <var>url</var> <a>is not special</a>.

--- a/url.bs
+++ b/url.bs
@@ -100,208 +100,189 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
   <tr>
    <td><dfn id=validation-error-domain-to-ascii>domain-to-ASCII</dfn>
    <td>
-    <p>The result of <a abstract-op lt=ToASCII>Unicode toASCII</a> records an error while processing
+    <p>The result of <a abstract-op lt=ToASCII>Unicode ToASCII</a> records an error while processing
     the input domain.
     <p class=note>[[!UTS46]] conformance does not require the reporting of precise errors, only that
     an error has occurred. If the [[!UTS46]] implementation reports precise error codes, user agents
     are encouraged pass those codes along.
-   <td>✅
+   <td>Yes
   <tr>
    <td><dfn>domain-to-ASCII-empty</dfn>
    <td>
-    <p>The result of <a abstract-op lt=ToASCII>Unicode toASCII</a> returns an empty string. This
+    <p>The result of <a abstract-op lt=ToASCII>Unicode ToASCII</a> returns an empty string. This
     could have been caused by:
     <ul>
      <li>Input consists of all ignorable code points.
      <li>Input is the string "<code>xn--</code>".
      <li>Input is the empty string and the <i>VerifyDnsLength</i> parameter is false.
     </ul>
-   <td>✅
+   <td>Yes
   <tr>
    <td><dfn>domain-to-Unicode</dfn>
    <td>
-    <p>The result of <a abstract-op lt=ToUnicode>Unicode toUnicode</a> returns an error while
+    <p>The result of <a abstract-op lt=ToUnicode>Unicode ToUnicode</a> returns an error while
     processing the input domain.
     <p class=note>The same considerations as with <a>domain-to-ASCII</a> apply.
-   <td>❌
+   <td>·
  <tbody>
   <tr>
    <th colspan=3 scope=rowgroup><a href=#host-parsing>Host parsing</a>
   <!-- host parser -->
   <tr>
-   <td><dfn>unclosed-IPv6-address</dfn>
+   <td><dfn>IPv6-unclosed</dfn>
    <td>
     <p>An IPv6 address is missing the closing U+005D (]).
-    <p class=example id=example-unclosed-ipv6-address>"<code>https://[::1</code>"
-   <td>✅
+    <p class=example id=example-ipv6-unclosed"<code>https://[::1</code>"
+   <td>Yes
   <tr>
-   <td><dfn id=validation-error-forbidden-domain-code-point>forbidden-domain-code-point</dfn>
+   <td><dfn>domain-invalid-code-point</dfn>
    <td>
     <p>The input's host contains a <a>forbidden domain code point</a>.
-    <div class=example id=example-forbidden-domain-code-point>
+    <div class=example id=example-domain-invalid-code-point>
      <p>Hosts are <a for=string>percent-decoded</a> before being processed when the URL
      <a>is special</a>, which would result in the following host portion becoming
      "<code>exa#mple.org</code>".
      <p>"<code>https://exa%23mple.org</code>"
     </div>
-   <td>✅
+   <td>Yes
   <!-- IPv4 parser -->
   <tr>
-   <td><dfn>empty-IPv4-part</dfn>
+   <td><dfn>IPv4-empty-part</dfn>
    <td>
     <p>Input to the <a>IPv4 parser</a> ends with a U+002E.
-    <p class=example id=example-empty-ipv4-part>"<code>https://127.0.0.1./</code>"
-   <td>❌
+    <p class=example id=example-ipv4-empty-part>"<code>https://127.0.0.1./</code>"
+   <td>·
   <tr>
-   <td><dfn>too-many-IPv4-parts</dfn>
+   <td><dfn>IPv4-too-many-parts</dfn>
    <td>
-    <p>An <a for=/>IPv4 address</a> consists of 4 parts.
-    <p class=example id=example-too-many-ipv4-parts>"<code>https://1.2.3.4.5/</code>"
-   <td>✅
+    <p>An <a for=/>IPv4 address</a> has to consist of 4 parts.
+    <p class=example id=example-ipv4-too-many-parts>"<code>https://1.2.3.4.5/</code>"
+   <td>Yes
   <tr>
-   <td><dfn>non-numeric-IPv4-part</dfn>
+   <td><dfn>IPv4-non-numeric-part</dfn>
    <td>
-    <p>An IPv4 part was not numeric.
-    <p class=example id=example-non-numeric-ipv4-part>"<code>https://test.42</code>"
-   <td>✅
+    <p>An <a for=/>IPv4 address</a> part was not numeric.
+    <p class=example id=example-ipv4-non-numeric-part>"<code>https://test.42</code>"
+   <td>Yes
   <tr>
-   <td><dfn>non-decimal-IPv4-part</dfn>
+   <td><dfn>IPv4-non-decimal-part</dfn>
    <td>
-    <p>The IPv4 address contains numbers expressed using hexadecimal or octal digits.
-    <p class=example id=example-non-decimal-ipv4-part>"<code>https://127.0.0x0.1</code>"
-   <td>❌
+    <p>The <a for=/>IPv4 address</a> contains numbers expressed using hexadecimal or octal digits.
+    <p class=example id=example-ipv4-non-decimal-part>"<code>https://127.0.0x0.1</code>"
+   <td>·
   <tr>
-   <td><dfn>IPv4-part-out-of-range</dfn>
+   <td><dfn>IPv4-out-of-range-part</dfn>
    <td>
-    <p>An IPv4 part exceeds 255.
-    <p class=example id=example-ipv4-part-out-of-range>"<code>https://255.255.4000.1</code>"
-   <td>✅ (only if applicable to the last IPv4 part)
+    <p>An <a for=/>IPv4 address</a> part exceeds 255.
+    <p class=example id=example-ipv4-out-of-range-part>"<code>https://255.255.4000.1</code>"
+   <td>Yes (only if applicable to the last part)
   <!-- IPv6 parser -->
   <tr>
-   <td><dfn>invalid-compressed-IPv6-address</dfn>
+   <td><dfn>IPv6-invalid-compression</dfn>
    <td>
-    <p>An IPv6 address begins with improper compression.
-    <p class=example id=example-invalid-compressed-ipv6-address>"<code>https://[:1]</code>"
-   <td>✅
+    <p>An <a for=/>IPv6 address</a> begins with improper compression.
+    <p class=example id=example-ipv6-invalid-compression>"<code>https://[:1]</code>"
+   <td>Yes
   <tr>
    <td><dfn>IPv6-too-many-pieces</dfn>
    <td>
-    <p>An IPv6 address contains more than 8 pieces.
+    <p>An <a for=/>IPv6 address</a> contains more than 8 pieces.
     <p class=example id=example-ipv6-too-many-pieces>"<code>https://[1:2:3:4:5:6:7:8:9]</code>"
-   <td>✅
+   <td>Yes
   <tr>
    <td><dfn>IPv6-multiple-compression</dfn>
    <td>
-    <p>An IPv6 address is compressed in more than one spot.
+    <p>An <a for=/>IPv6 address</a> is compressed in more than one spot.
     <p class=example id=example-ipv6-multiple-compression>"<code>https://[1::1::1]</code>"
-   <td>✅
+   <td>Yes
   <tr>
    <td><dfn>IPv4-in-IPv6-empty-part</dfn>
    <td>
-    <p>An IPv6 address that contains an IPv4 address has an empty part in the IPv4 address.
+    <p>An <a for=/>IPv6 address</a> with <a for=/>IPv4 address</a> syntax: an empty part in the
+    IPv4 address.
     <p class=example id=example-ipv4-in-ipv6-empty-part>"<code>https://[ffff::.0.0.1]</code>"
-   <td>✅
+   <td>Yes
   <tr>
    <td><dfn>IPv4-in-IPv6-too-many-pieces</dfn>
    <td>
-    <p>An IPv6 address contains an IPv4 address and the IPv6 address has more than 6 pieces.
+    <p>An <a for=/>IPv6 address</a> with <a for=/>IPv4 address</a> syntax: the IPv6 address has more
+    than 6 pieces.
     <p class=example id=example-ipv4-in-ipv6-too-many-pieces>"<code>https://[1:1:1:1:1:1:1:127.0.0.1]</code>"
-   <td>✅
+   <td>Yes
   <tr>
-   <td><dfn>IPv4-in-IPv6-too-many-parts</dfn>
+   <td><dfn>IPv4-in-IPv6-invalid-code-point</dfn>
    <td>
-    <p>An IPv6 address contains an IPv4 address and the IPv4 address has more than 4 parts.
-    <p class=example id=example-ipv4-in-ipv6-too-many-parts>"<code>https://[ffff::127.0.0.1.2]</code>"
-   <td>✅
+    <p>An <a for=/>IPv6 address</a> with <a for=/>IPv4 address</a> syntax:
+    <ul>
+     <li>An IPv4 part is empty or contains a non-<a>ASCII digit</a>.
+     <li>An IPv4 part contains a leading 0.
+     <li>There are too many IPv4 parts.
+    </ul>
+    <div class=example id=example-ipv4-in-ipv6-invalid-code-point>
+     <p>"<code>https://[ffff::127.0.xyz.1]</code>"
+     <p>"<code>https://[ffff::127.0xyz]</code>"
+     <p>"<code>https://[ffff::127.00.0.1]</code>"
+     <p>"<code>https://[ffff::127.0.0.1.2]</code>"
+    </div>
+   <td>Yes
   <tr>
-   <td><dfn>IPv4-in-IPv6-unexpected-code-point</dfn>
+   <td><dfn>IPv4-in-IPv6-out-of-range-part</dfn>
    <td>
-    <p>An IPv6 address contains an IPv4 address of which a part contain a code point other than an
-    <a>ASCII digits</a> or is the empty string.
-    <p class=example id=example-ipv4-in-ipv6-unexpected-code-point>"<code>https://[ffff::127.0.xyz.1]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv4-in-IPv6-invalid-first-part</dfn>
-   <td>
-    <p>The first part of an IPv4 address that is contained within an IPv6 address is 0.
-    <p class=example id=example-ipv4-in-ipv6-invalid-first-part>"<code>https://[ffff::0.0.0.1]</code>"
-   <td>✅
-  <tr>
-   <td><dfn>IPv4-in-IPv6-part-out-of-range</dfn>
-   <td>
-    <p>An IPv4 address contained within an IPv6 address contains a part that exceeds 255.
-    <p class=example id=example-ipv4-in-ipv6-part-out-of-range>"<code>https://[ffff::127.0.0.4000]</code>"
-   <td>✅
+    <p>An <a for=/>IPv6 address</a> with <a for=/>IPv4 address</a> syntax: an IPv4 part exceeds 255.
+    <p class=example id=example-ipv4-in-ipv6-out-of-range-part>"<code>https://[ffff::127.0.0.4000]</code>"
+   <td>Yes
   <tr>
    <td><dfn>IPv4-in-IPv6-too-few-parts</dfn>
    <td>
-    <p>An IPv4 address contained within an IPv6 address does not contain exactly 4 parts.
+    <p>An <a for=/>IPv6 address</a> with <a for=/>IPv4 address</a> syntax: an IPv4 address contains
+    too few parts.
     <p class=example id=example-ipv4-in-ipv6-too-few-parts>"<code>https://[ffff::127.0.0]</code>"
-   <td>✅
+   <td>Yes
   <tr>
    <td><dfn>IPv6-unexpected-EOF</dfn>
    <td>
-    <p>An IPv6 address unexpectedly ends.
+    <p>An <a for=/>IPv6 address</a> unexpectedly ends.
     <p class=example id=example-ipv6-unexpected-eof>"<code>https://[1:2:3:]</code>"
-   <td>✅
+   <td>Yes
   <tr>
-   <td><dfn>IPv6-unexpected-delimiter</dfn>
+   <td><dfn>IPv6-invalid-code-point</dfn>
    <td>
-    <p>An IPv6 address contains a code point that is neither an <a>ASCII hex digit</a> nor a
-    U+003A (:).
-    <p class=example id=example-ipv6-unexpected-delimiter>"<code>https://[1:2:3!:4]</code>"
-   <td>✅
+    <p>An <a for=/>IPv6 address</a> contains a code point that is neither an <a>ASCII hex digit</a>
+    nor a U+003A (:).
+    <p class=example id=example-ipv6-invalid-code-point>"<code>https://[1:2:3!:4]</code>"
+   <td>Yes
   <tr>
    <td><dfn>IPv6-too-few-pieces</dfn>
    <td>
-    <p>An uncompressed IPv6 address contains fewer than 8 pieces.
+    <p>An uncompressed <a for=/>IPv6 address</a> contains fewer than 8 pieces.
     <p class=example id=example-ipv6-too-few-pieces>"<code>https://[1:2:3]</code>"
-   <td>✅
+   <td>Yes
   <!-- opaque-host parser -->
   <tr>
-   <td><dfn id=validation-error-forbidden-host-code-point>forbidden-host-code-point</dfn>
+   <td><dfn>host-invalid-code-point</dfn>
    <td>
-    <p>When an <a>opaque host</a> (in a URL that <a>is not special</a>) contains a
+    <p>An <a>opaque host</a> (in a URL that <a>is not special</a>) contains a
     <a>forbidden host code point</a>.
-   <p class=example id=example-forbidden-host-code-point>"<code>foo://exa[mple.org</code>"
-   <td>✅
+    <p class=example id=example-host-invalid-code-point>"<code>foo://exa[mple.org</code>"
+   <td>Yes
  <tbody>
   <tr>
    <th colspan=3 scope=rowgroup><a href=#url-parsing>URL parsing</a>
   <tr>
-   <td><dfn>unexpected-C0-control-or-space</dfn>
+   <td><dfn>scheme-invalid-code-point</dfn>
    <td>
-    <p>The input to the <a>URL parser</a> contains a leading or trailing <a>C0 control or space</a>. The
-    URL parser subsequently strips any matching code points.
-    <p class=example id=example-unexpected-c0-control-or-space>"<code> https://example.org </code>"
-   <td>❌
-  <tr>
-   <td><dfn>unexpected-ASCII-tab-or-newline</dfn>
-   <td>
-    <p>The input to the URL parser contains <a>ASCII tab or newlines</a>. The URL parser
-    subsequently strips any matching code points.
-    <p class=example id=example-unexpected-ascii-tab-or-newline>"<code>ht<br>tps://example.org</code>"
-   <td>❌
-  <tr>
-   <td><dfn>invalid-scheme-start</dfn>
-   <td>
-    <p>The first code point of a URL's <a for=url>scheme</a> is not an <a>ASCII alpha</a>.
-    <p class=example id=example-invalid-scheme-start>"3ttps://example.org"
-   <td>✅
+    <p>The URL's <a for=url>scheme</a> contains an invalid code point.
+    <div class=example id=example-scheme-invalid-code-point>
+     TODO: actual setter examples as prior examples were wrong
+    </div>
+   <td>Yes
   <tr>
    <td><dfn>file-scheme-missing-following-solidus</dfn>
    <td>
     <p>The URL parser encounters a URL with a "<code>file</code>" <a for=url>scheme</a> that is not
     followed by "<code>//</code>".
     <p class=example id=example-file-scheme-missing-following-solidus>"<code>file:c:/my-secret-folder</code>"
-   <td>❌
-  <tr>
-   <td><dfn>invalid-scheme</dfn>
-   <td>
-    <p>The URL's <a for=url>scheme</a> contains an invalid code point.
-    <p class=example id=example-invalid-scheme>"<code>^_^://example.org</code>" and
-    "<code>https//example.org</code>"
-   <td>✅
+   <td>·
   <tr>
    <td><dfn>missing-scheme-non-relative-URL</dfn>
    <td>
@@ -317,103 +298,89 @@ let url = new URL("💩");</code></pre>
      <pre><code class=lang-javascript>
 let url = new URL("💩", "mailto:user@example.org");</code></pre>
     </div>
-   <td>✅
+   <td>Yes
   <tr>
    <td><dfn>relative-URL-missing-beginning-solidus</dfn>
    <td>
-    <p>The input is a <a>relative-URL String</a> that does not begin with U+002F (/).
+    <p>The input is a <a>relative-URL string</a> that does not begin with U+002F (/).
     <pre class=example id=example-relative-url-missing-beginning-solidus><code class="lang-javascript">
 let url = new URL("foo.html", "https://example.org/");</code></pre>
-   <td>❌
+   <td>·
   <tr>
-   <td><dfn>unexpected-reverse-solidus</dfn>
+   <td><dfn>invalid-reverse-solidus</dfn>
    <td>
     <p>The URL has a <a>special scheme</a> and it uses U+005C (\) instead of U+002F (/).
-    <p class=example id=example-unexpected-reverse-solidus>"<code>https://example.org\path\to\file</code>"
-   <td>❌
+    <p class=example id=example-invalid-reverse-solidus>"<code>https://example.org\path\to\file</code>"
+   <td>·
   <tr>
-   <td><dfn>missing-solidus-before-authority</dfn>
+   <td><dfn>host-missing-solidus</dfn>
    <td>
-    <p>The URL <a>includes credentials</a> that are not preceded by "<code>//</code>".
-    <p class=example id=example-missing-solidus-before-authority>"<code>https:user@example.org</code>"
-   <td>❌
+    <p>The URL's <a for=url>host</a> is not preceded by "<code>//</code>".
+    <p class=example id=example-host-missing-solidus>"<code>https:example.org</code>"
+   <td>·
   <tr>
-   <td><dfn>unexpected-at-sign</dfn>
+   <td><dfn>invalid-credentials</dfn>
    <td>
-    <p>The URL <a>includes credentials</a>, however this is considered invalid.
-    <p class=example id=example-unexpected-at-sign>"<code>https://user@example.org</code>"
-   <td>❌
+    <p>The URL <a>includes credentials</a>.
+    <div class=example id=example-invalid-credentials>
+     <p>"<code>https://user@example.org</code>"
+     <p>"<code>https://user:pass@</code>"
+    </div>
+   <td>Yes (only if there is no host)
   <tr>
-   <td><dfn>unexpected-credentials-without-host</dfn>
+   <td><dfn>host-empty</dfn>
    <td>
-    <p>The URL <a>include credentials</a>, but no <a for=url>host</a>.
-    <p class=example id=example-unexpected-credentials-without-host>"<code>https://user:pass@</code>"
-   <td>✅
-  <tr>
-   <td><dfn>unexpected-port-without-host</dfn>
-   <td>
-    <p>The URL contains a <a for=url>port</a>, but no <a for=url>host</a>.
-    <p class=example id=example-unexpected-port-without-host>"<code>https://:443</code>"
-   <td>✅
-  <tr>
-   <td><dfn>empty-host-special-scheme</dfn>
-   <td>
-    <p>The URL has a <a>special scheme</a>, but does not contain a <a for=url>host</a>.
-    <p class=example id=example-empty-host-special-scheme>"<code>https://#fragment</code>"
-   <td>✅
-  <tr>
-   <td><dfn>host-invalid</dfn>
-   <td>
-    <p>The <a for=url>host</a> portion of the URL is an empty string when it
-    <a>includes credentials</a> or a <a>port</a> and the <a>basic URL parser</a>'s state is
-    overridden.
-    <pre class=example id=example-host-invalid><code class=lang-javascript>
+    <p>The URL has a <a>special scheme</a>, but does not contain a <a for=url>host</a>. Or the
+    <a for=url>host</a> portion of the URL is an empty string when it <a>includes credentials</a> or
+    a <a>port</a> and the <a>basic URL parser</a>'s state is overridden.
+    <div class=example id=example-host-empty>
+     <p>"<code>https://#fragment</code>"
+     <p>"<code>https://:443</code>"
+     <pre><code class=lang-javascript>
 const url = new URL("https://example:9000");
 url.hostname = "";</code></pre>
-   <td>❌
+    </div>
+   <td>·
   <tr>
    <td><dfn>port-out-of-range</dfn>
    <td>
     <p>The input's port is too big.
     <p class=example id=example-port-out-of-range>"<code>https://example.org:70000</code>"
-   <td>✅
+   <td>Yes
   <tr>
    <td><dfn>port-invalid</dfn>
    <td>
     <p>The input's port is invalid.
     <p class=example id=example-port-invalid>"<code>https://example.org:7z</code>"
-   <td>✅
+   <td>Yes
   <tr>
-   <td><dfn>unexpected-Windows-drive-letter</dfn>
+   <td><dfn>file-invalid-Windows-drive-letter</dfn>
    <td>
     <p>The input is a <a>relative-URL string</a> that <a>starts with a Windows drive letter</a> and
     the <a>base URL</a>'s <a for=url>scheme</a> is "<code>file</code>".
-    <pre class=example id=example-unexpected-windows-drive-letter><code class=lang-javascript>
+    <pre class=example id=example-file-invalid-windows-drive-letter><code class=lang-javascript>
 let url = new URL("/c:/path/to/file", "file:///c:/");</code></pre>
-   <td>❌
+   <td>·
   <tr>
-   <td><dfn>unexpected-Windows-drive-letter-host</dfn>
+   <td><dfn>file-invalid-Windows-drive-letter-host</dfn>
    <td>
-    <p>The file URL's host is a Windows drive letter.
-    <p class=example id=example-unexpected-windows-drive-letter-host>"<code>file://c:</code>"
-   <td>❌
+    <p>A <code>file:</code> URL's host is a Windows drive letter.
+    <p class=example id=example-file-invalid-windows-drive-letter-host>"<code>file://c:</code>"
+   <td>·
  <tbody>
   <tr>
    <th colspan=3 scope=rowgroup>URL parsing and <a>opaque-host parser</a>
   <tr>
-   <td><dfn>invalid-URL-code-point</dfn>
+   <td><dfn>invalid-URL-unit</dfn>
    <td>
-    <p>A code point is found that is not a <a>URL code point</a> or U+0025 (%), in the URL's
-    <a for=url>path</a>, <a for=url>query</a>, or <a for=url>fragment</a>.
-    <p class=example id=example-invalid-url-code-point>"<code>https://example.org/></code>"
-   <td>❌
-  <tr>
-   <td><dfn>unescaped-percent-sign</dfn>
-   <td>
-    <p>A U+0025 (%) is found that is not followed by two <a>ASCII hex digits</a>, in the URL's
-    <a for=url>path</a>, <a for=url>query</a>, or <a for=url>fragment</a>.
-    <p class=example id=example-unescaped-percent-sign>"<code>https://example.org/%s</code>"
-   <td>❌
+    <p>A code point is found that is not a <a>URL unit</a>.
+    <div class=example id=example-invalid-url-unit>
+     <p>"<code>https://example.org/></code>"
+     <p>"<code> https://example.org </code>"
+     <p>"<code>ht<br>tps://example.org</code>"
+     <p>"<code>https://example.org/%s</code>"
+    </div>
+   <td>·
 </table>
 
 
@@ -1073,7 +1040,7 @@ to be distinguished.
   <p>If <var>input</var> starts with U+005B ([), then:
 
   <ol>
-   <li><p>If <var>input</var> does not end with U+005D (]), <a>unclosed-IPv6-address</a>
+   <li><p>If <var>input</var> does not end with U+005D (]), <a>IPv6-unclosed</a>
    <a>validation error</a>, return failure.
 
    <li><p>Return the result of <a lt="IPv6 parser">IPv6 parsing</a> <var>input</var> with its
@@ -1098,7 +1065,7 @@ to be distinguished.
  <li><p>If <var>asciiDomain</var> is failure, then return failure.
 
  <li><p>If <var>asciiDomain</var> contains a <a>forbidden domain code point</a>,
- <a>forbidden-domain-code-point</a> <a>validation error</a>, return failure.
+ <a>domain-invalid-code-point</a> <a>validation error</a>, return failure.
 
  <li><p>If <var>asciiDomain</var> <a lt="ends in a number checker">ends in a number</a>, then return
  the result of <a lt="IPv4 parser">IPv4 parsing</a> <var>asciiDomain</var>.
@@ -1160,7 +1127,7 @@ return value of the <a for=/>host parser</a> is an <a for=/>IPv4 address</a>.
   <p>If the last <a for=list>item</a> in <var>parts</var> is the empty string, then:
 
   <ol>
-   <li><p><a>Empty-IPv4-part</a> <a>validation error</a>.
+   <li><p><a>IPv4-empty-part</a> <a>validation error</a>.
 
    <li><p>If <var>parts</var>'s <a for=list>size</a> is greater than 1, then <a for=list>remove</a>
    the last <a for=list>item</a> from <var>parts</var>.
@@ -1168,7 +1135,7 @@ return value of the <a for=/>host parser</a> is an <a for=/>IPv4 address</a>.
         but if it somehow is this conditional makes sure we can keep going. -->
   </ol>
 
- <li><p>If <var>parts</var>'s <a for=list>size</a> is greater than 4, <a>too-many-IPv4-parts</a>
+ <li><p>If <var>parts</var>'s <a for=list>size</a> is greater than 4, <a>IPv4-too-many-parts</a>
  <a>validation error</a>, return failure.
 
  <li><p>Let <var>numbers</var> be an empty <a for=/>list</a>.
@@ -1180,15 +1147,15 @@ return value of the <a for=/>host parser</a> is an <a for=/>IPv4 address</a>.
    <li><p>Let <var>result</var> be the result of <a lt="IPv4 number parser">parsing</a>
    <var>part</var>.
 
-   <li><p>If <var>result</var> is failure, <a>non-numeric-IPv4-part</a> <a>validation error</a>,
+   <li><p>If <var>result</var> is failure, <a>IPv4-non-numeric-part</a> <a>validation error</a>,
    return failure.
 
-   <li><p>If <var>result</var>[1] is true, <a>non-decimal-IPv4-part</a> <a>validation error</a>.
+   <li><p>If <var>result</var>[1] is true, <a>IPv4-non-decimal-part</a> <a>validation error</a>.
 
    <li><p><a for=list>Append</a> <var>result</var>[0] to <var>numbers</var>.
   </ol>
 
- <li><p>If any item in <var>numbers</var> is greater than 255, <a>IPv4-part-out-of-range</a>
+ <li><p>If any item in <var>numbers</var> is greater than 255, <a>IPv4-out-of-range-part</a>
  <a>validation error</a>.
 
  <li><p>If any but the last <a for=list>item</a> in <var>numbers</var> is greater than 255, then
@@ -1292,8 +1259,8 @@ actually doing that with the editors of this document first.
   <p>If <a>c</a> is U+003A (:), then:
 
   <ol>
-   <li><p>If <a>remaining</a> does not start with U+003A (:),
-   <a>invalid-compressed-IPv6-address</a> <a>validation error</a>, return failure.
+   <li><p>If <a>remaining</a> does not start with U+003A (:), <a>IPv6-invalid-compression</a>
+   <a>validation error</a>, return failure.
 
    <li><p>Increase <var>pointer</var> by 2.
 
@@ -1352,10 +1319,11 @@ actually doing that with the editors of this document first.
          <li><p>If <a>c</a> is a U+002E (.) and <var>numbersSeen</var> is less than 4, then increase
          <var>pointer</var> by 1.
 
-         <li>Otherwise, <a>IPv4-in-IPv6-too-many-parts</a> <a>validation error</a>, return failure.
+         <li>Otherwise, <a>IPv4-in-IPv6-invalid-code-point</a> <a>validation error</a>, return
+         failure.
         </ol>
 
-       <li><p>If <a>c</a> is not an <a>ASCII digit</a>, <a>IPv4-in-IPv6-unexpected-code-point</a>
+       <li><p>If <a>c</a> is not an <a>ASCII digit</a>, <a>IPv4-in-IPv6-invalid-code-point</a>
        <a>validation error</a>, return failure.
        <!-- prevent the empty string -->
 
@@ -1368,7 +1336,7 @@ actually doing that with the editors of this document first.
          <li>
           <p>If <var>ipv4Piece</var> is null, then set <var>ipv4Piece</var> to <var>number</var>.
 
-          <p>Otherwise, if <var>ipv4Piece</var> is 0, <a>IPv4-in-IPv6-invalid-first-part</a>
+          <p>Otherwise, if <var>ipv4Piece</var> is 0, <a>IPv4-in-IPv6-invalid-code-point</a>
           <a>validation error</a>, return failure.
 
           <p>Otherwise, set <var>ipv4Piece</var> to <var>ipv4Piece</var> &times; 10 +
@@ -1404,7 +1372,7 @@ actually doing that with the editors of this document first.
      <a>validation error</a>, return failure.
     </ol>
 
-   <li><p>Otherwise, if <a>c</a> is not the <a>EOF code point</a>, <a>IPv6-unexpected-delimiter</a>
+   <li><p>Otherwise, if <a>c</a> is not the <a>EOF code point</a>, <a>IPv6-invalid-code-point</a>
    <a>validation error</a>, return failure.
 
    <li><p>Set <var>address</var>[<var>pieceIndex</var>] to <var>value</var>.
@@ -1442,13 +1410,13 @@ actually doing that with the editors of this document first.
 
 <ol>
  <li><p>If <var>input</var> contains a <a>forbidden host code point</a>,
- <a>forbidden-host-code-point</a> <a>validation error</a>, return failure.
+ <a>host-invalid-code-point</a> <a>validation error</a>, return failure.
 
  <li><p>If <var>input</var> contains a <a>code point</a> that is not a <a>URL code point</a> and not
- U+0025 (%), <a>invalid-URL-code-point</a> <a>validation error</a>.
+ U+0025 (%), <a>invalid-URL-unit</a> <a>validation error</a>.
 
  <li><p>If <var>input</var> contains a U+0025 (%) and the two <a>code points</a> following it are
- not <a>ASCII hex digits</a>, <a>unescaped-percent-sign</a> <a>validation error</a>.
+ not <a>ASCII hex digits</a>, <a>invalid-URL-unit</a> <a>validation error</a>.
 
  <li><p>Return the result of running <a for=string>UTF-8 percent-encode</a> on <var>input</var>
  using the <a>C0 control percent-encode set</a>.
@@ -2193,13 +2161,13 @@ and then runs these steps:
    <li><p>Set <var>url</var> to a new <a for=/>URL</a>.
 
    <li><p>If <var>input</var> contains any leading or trailing <a>C0 control or space</a>,
-   <a>unexpected-C0-control-or-space</a> <a>validation error</a>.
+   <a>invalid-URL-unit</a> <a>validation error</a>.
 
    <li><p>Remove any leading and trailing <a>C0 control or space</a> from <var>input</var>.
   </ol>
 
- <li><p>If <var>input</var> contains any <a>ASCII tab or newline</a>,
- <a>unexpected-ASCII-tab-or-newline</a> <a>validation error</a>.
+ <li><p>If <var>input</var> contains any <a>ASCII tab or newline</a>, <a>invalid-URL-unit</a>
+ <a>validation error</a>.
 
  <li><p>Remove all <a>ASCII tab or newline</a> from <var>input</var>.
 
@@ -2233,7 +2201,7 @@ and then runs these steps:
      <a>no scheme state</a> and decrease <var>pointer</var> by 1.
 
      <li>
-      <p>Otherwise, <a>invalid-scheme-start</a> <a>validation error</a>, return failure.
+      <p>Otherwise, <a>scheme-invalid-code-point</a> <a>validation error</a>, return failure.
 
       <p class=note>This indication of failure is used exclusively by the {{Location}} object's
       {{Location/protocol}} setter.
@@ -2317,7 +2285,7 @@ and then runs these steps:
      in <var>input</var>).
 
      <li>
-      <p>Otherwise, <a>invalid-scheme</a> <a>validation error</a>, return failure.
+      <p>Otherwise, <a>scheme-invalid-code-point</a> <a>validation error</a>, return failure.
 
       <p class=note>This indication of failure is used exclusively by the {{Location}} object's
       {{Location/protocol}} setter. Furthermore, the non-failure termination earlier in this state
@@ -2378,7 +2346,7 @@ and then runs these steps:
      <li><p>If <a>c</a> is U+002F (/), then set <var>state</var> to <a>relative slash state</a>.
 
      <li><p>Otherwise, if <var>url</var> <a>is special</a> and <a>c</a> is U+005C (\),
-     <a>unexpected-reverse-solidus</a> <a>validation error</a>, set <var>state</var> to
+     <a>invalid-reverse-solidus</a> <a>validation error</a>, set <var>state</var> to
      <a>relative slash state</a>.
 
      <li>
@@ -2424,7 +2392,7 @@ and then runs these steps:
       <p>If <var>url</var> <a>is special</a> and <a>c</a> is U+002F (/) or U+005C (\), then:
 
       <ol>
-       <li><p>If <a>c</a> is U+005C (\), <a>unexpected-reverse-solidus</a>
+       <li><p>If <a>c</a> is U+005C (\), <a>invalid-reverse-solidus</a>
        <a>validation error</a>.
 
        <li><p>Set <var>state</var> to <a>special authority ignore slashes state</a>.
@@ -2452,9 +2420,8 @@ and then runs these steps:
      <var>state</var> to <a>special authority ignore slashes state</a> and increase
      <var>pointer</var> by 1.
 
-     <li><p>Otherwise, <a>missing-solidus-before-authority</a> <a>validation error</a>, set
-     <var>state</var> to <a>special authority ignore slashes state</a> and decrease
-     <var>pointer</var> by 1.
+     <li><p>Otherwise, <a>host-missing-solidus</a> <a>validation error</a>, set <var>state</var> to
+     <a>special authority ignore slashes state</a> and decrease <var>pointer</var> by 1.
     </ol>
 
    <dt><dfn export for="basic URL parser" id=special-authority-ignore-slashes-state>special authority ignore slashes state</dfn>
@@ -2463,7 +2430,7 @@ and then runs these steps:
      <li><p>If <a>c</a> is neither U+002F (/) nor U+005C (\), then set <var>state</var> to
      <a>authority state</a> and decrease <var>pointer</var> by 1.
 
-     <li><p>Otherwise, <a>missing-solidus-before-authority</a> <a>validation error</a>.
+     <li><p>Otherwise, <a>host-missing-solidus</a> <a>validation error</a>.
     </ol>
 
    <dt><dfn export for="basic URL parser" id=authority-state>authority state</dfn>
@@ -2473,7 +2440,7 @@ and then runs these steps:
       <p>If <a>c</a> is U+0040 (@), then:
 
       <ol>
-       <li><p><a>Unexpected-at-sign</a> <a>validation error</a>.
+       <li><p><a>Invalid-credentials</a> <a>validation error</a>.
 
        <li><p>If <var>atSignSeen</var> is true, then prepend "<code>%40</code>" to
        <var>buffer</var>.
@@ -2513,7 +2480,7 @@ and then runs these steps:
 
       <ol>
        <li><p>If <var>atSignSeen</var> is true and <var>buffer</var> is the empty string,
-       <a>unexpected-credentials-without-host</a> <a>validation error</a>, return failure.
+       <a>invalid-credentials</a> <a>validation error</a>, return failure.
        <!-- No URLs with userinfo, but without host. For special URLs it would also not be
             idempotent:
             https://@/example.org/ -> https:///example.org/ -> https://example.org/ -->
@@ -2538,8 +2505,8 @@ and then runs these steps:
       <p>Otherwise, if <a>c</a> is U+003A (:) and <var>insideBrackets</var> is false, then:
 
       <ol>
-       <li><p>If <var>buffer</var> is the empty string, <a>unexpected-port-without-host</a>
-       <a>validation error</a>, return failure.
+       <li><p>If <var>buffer</var> is the empty string, <a>host-empty</a> <a>validation error</a>,
+       return failure.
        <!-- No URLs with port, but without host. -->
 
        <li><p>If <var>state override</var> is given and <var>state override</var> is
@@ -2567,13 +2534,13 @@ and then runs these steps:
 
       <ol>
        <li><p>If <var>url</var> <a>is special</a> and <var>buffer</var> is the empty string,
-       <a>empty-host-special-scheme</a> <a>validation error</a>, return failure.
+       <a>host-empty</a> <a>validation error</a>, return failure.
        <!-- http://? -> failure
             test://? -> test://? -->
 
        <li><p>Otherwise, if <var>state override</var> is given, <var>buffer</var> is the empty
        string, and either <var>url</var> <a>includes credentials</a> or <var>url</var>'s
-       <a for=url>port</a> is non-null, <a>host-invalid</a> <a>validation error</a>, return.
+       <a for=url>port</a> is non-null, <a>host-empty</a> <a>validation error</a>, return.
 
        <li><p>Let <var>host</var> be the result of <a>host parsing</a> <var>buffer</var> with
        <var>url</var> <a>is not special</a>.
@@ -2652,7 +2619,7 @@ and then runs these steps:
       <p>If <a>c</a> is U+002F (/) or U+005C (\), then:
 
       <ol>
-       <li><p>If <a>c</a> is U+005C (\), <a>unexpected-reverse-solidus</a> <a>validation error</a>.
+       <li><p>If <a>c</a> is U+005C (\), <a>invalid-reverse-solidus</a> <a>validation error</a>.
 
        <li><p>Set <var>state</var> to <a>file slash state</a>.
       </ol>
@@ -2689,7 +2656,7 @@ and then runs these steps:
           <p>Otherwise:
 
           <ol>
-           <li><p><a>Unexpected-Windows-drive-letter</a> <a>validation error</a>.
+           <li><p><a>File-invalid-Windows-drive-letter</a> <a>validation error</a>.
 
            <li><p>Set <var>url</var>'s <a for=url>path</a> to « ».
           </ol>
@@ -2711,7 +2678,7 @@ and then runs these steps:
       <p>If <a>c</a> is U+002F (/) or U+005C (\), then:
 
       <ol>
-       <li><p>If <a>c</a> is U+005C (\), <a>unexpected-reverse-solidus</a> <a>validation error</a>.
+       <li><p>If <a>c</a> is U+005C (\), <a>invalid-reverse-solidus</a> <a>validation error</a>.
 
        <li><p>Set <var>state</var> to <a>file host state</a>.
       </ol>
@@ -2752,7 +2719,7 @@ and then runs these steps:
       <ol>
        <li>
         <p>If <var>state override</var> is not given and <var>buffer</var> is a
-        <a>Windows drive letter</a>, <a>unexpected-Windows-drive-letter-host</a>
+        <a>Windows drive letter</a>, <a>file-invalid-Windows-drive-letter-host</a>
         <a>validation error</a>, set <var>state</var> to <a>path state</a>.
 
         <p class=note>This is a (platform-independent) Windows drive letter quirk. <var>buffer</var>
@@ -2800,7 +2767,7 @@ and then runs these steps:
       <p>If <var>url</var> <a>is special</a>, then:
 
       <ol>
-       <li><p>If <a>c</a> is U+005C (\), <a>unexpected-reverse-solidus</a> <a>validation error</a>.
+       <li><p>If <a>c</a> is U+005C (\), <a>invalid-reverse-solidus</a> <a>validation error</a>.
 
        <li><p>Set <var>state</var> to <a>path state</a>.
 
@@ -2846,7 +2813,7 @@ and then runs these steps:
 
       <ol>
        <li><p>If <var>url</var> <a>is special</a> and <a>c</a> is U+005C (\),
-       <a>unexpected-reverse-solidus</a> <a>validation error</a>.
+       <a>invalid-reverse-solidus</a> <a>validation error</a>.
 
        <li>
         <p>If <var>buffer</var> is a <a>double-dot URL path segment</a>, then:
@@ -2896,10 +2863,10 @@ and then runs these steps:
 
       <ol>
        <li><p>If <a>c</a> is not a <a>URL code point</a> and not U+0025 (%),
-       <a>invalid-URL-code-point</a> <a>validation error</a>.
+       <a>invalid-URL-unit</a> <a>validation error</a>.
 
        <li><p>If <a>c</a> is U+0025 (%) and <a>remaining</a> does not start with two
-       <a>ASCII hex digits</a>, <a>unescaped-percent-sign</a> <a>validation error</a>.
+       <a>ASCII hex digits</a>, <a>invalid-URL-unit</a> <a>validation error</a>.
 
        <li><p><a for="code point">UTF-8 percent-encode</a> <a>c</a> using the
        <a>path percent-encode set</a> and append the result to <var>buffer</var>.
@@ -2920,10 +2887,10 @@ and then runs these steps:
 
       <ol>
        <li><p>If <a>c</a> is not the <a>EOF code point</a>, not a <a>URL code point</a>, and not
-       U+0025 (%), <a>invalid-URL-code-point</a> <a>validation error</a>.
+       U+0025 (%), <a>invalid-URL-unit</a> <a>validation error</a>.
 
        <li><p>If <a>c</a> is U+0025 (%) and <a>remaining</a> does not start with two
-       <a>ASCII hex digits</a>, <a>unescaped-percent-sign</a> <a>validation error</a>.
+       <a>ASCII hex digits</a>, <a>invalid-URL-unit</a> <a>validation error</a>.
 
        <li><p>If <a>c</a> is not the <a>EOF code point</a>,
        <a for="code point">UTF-8 percent-encode</a> <a>c</a> using the
@@ -2979,10 +2946,10 @@ and then runs these steps:
 
       <ol>
        <li><p>If <a>c</a> is not a <a>URL code point</a> and not U+0025 (%),
-       <a>invalid-URL-code-point</a> <a>validation error</a>.
+       <a>invalid-URL-unit</a> <a>validation error</a>.
 
        <li><p>If <a>c</a> is U+0025 (%) and <a>remaining</a> does not start with two
-       <a>ASCII hex digits</a>, <a>unescaped-percent-sign</a> <a>validation error</a>.
+       <a>ASCII hex digits</a>, <a>invalid-URL-unit</a> <a>validation error</a>.
 
        <li><p>Append <a>c</a> to <var>buffer</var>.
       </ol>
@@ -2996,10 +2963,10 @@ and then runs these steps:
 
       <ol>
        <li><p>If <a>c</a> is not a <a>URL code point</a> and not U+0025 (%),
-       <a>invalid-URL-code-point</a> <a>validation error</a>.
+       <a>invalid-URL-unit</a> <a>validation error</a>.
 
        <li><p>If <a>c</a> is U+0025 (%) and <a>remaining</a> does not start with two
-       <a>ASCII hex digits</a>, <a>unescaped-percent-sign</a> <a>validation error</a>.
+       <a>ASCII hex digits</a>, <a>invalid-URL-unit</a> <a>validation error</a>.
 
        <li><p><a for="code point">UTF-8 percent-encode</a> <a>c</a> using the
        <a>fragment percent-encode set</a> and append the result to <var>url</var>'s

--- a/url.bs
+++ b/url.bs
@@ -88,6 +88,301 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
  unclear to other developers.
 </div>
 
+<table>
+ <thead>
+  <tr>
+   <th>Error type
+   <th>Error description
+   <th>Failure
+ <tbody>
+  <tr>
+   <td><dfn>unexpected-C0-control-or-space</dfn>
+   <td>
+    <p>The input to the <a>URL parser</a> contains a leading or trailing <a>C0 control or space</a>. The
+    URL parser subsequently strips any matching code points.
+    <p class=example id=example-unexpected-c0-control-or-space>"<code> https://example.org </code>"
+   <td>❌
+  <tr>
+   <td><dfn>unexpected-ASCII-tab-or-newline</dfn>
+   <td>
+    <p>The input to the URL parser contains <a>ASCII tab or newlines</a>. The URL parser
+    subsequently strips any matching code points.
+    <p class=example id=example-unexpected-ascii-tab-or-newline>"<code>ht<br>tps://example.org</code>"
+   <td>❌
+  <tr>
+   <td><dfn>invalid-scheme-start</dfn>
+   <td>
+    <p>The first code point of a URL's <a for=url>scheme</a> is not an <a>ASCII alpha</a>.
+    <p class=example id=example-invalid-scheme-start>"3ttps://example.org"
+   <td>✅
+  <tr>
+   <td><dfn>file-scheme-missing-following-solidus</dfn>
+   <td>
+    <p>The URL parser encounters a URL with a "<code>file</code>" <a for=url>scheme</a> that is not
+    followed by "<code>//</code>".
+    <p class=example id=example-file-scheme-missing-following-solidus>"<code>file:c:/my-secret-folder</code>"
+   <td>❌
+  <tr>
+   <td><dfn>invalid-scheme</dfn>
+   <td>
+    <p>The URL's <a for=url>scheme</a> contains an invalid code point.
+    <p class=example id=example-invalid-scheme>"<code>^_^://example.org</code>" and
+    "<code>https//example.org</code>"
+   <td>✅
+  <tr>
+   <td><dfn>missing-scheme-non-relative-URL</dfn>
+   <td>
+    <p>The input is missing a <a for=url>scheme</a>, because it does not begin with an
+    <a>ASCII alpha</a>, and either no <a>base URL</a> was provided or the <a>base URL</a> cannot be
+    used as a <a>base URL</a> because it has an <a for=url>opaque path</a>.
+    <div class=example id=example-missing-scheme-non-relative-url>
+     <p>Input's <a for=url>scheme</a> is missing and no <a>base URL</a> is given:
+     <pre><code class=lang-javascript>
+let url = new URL("💩");</code></pre>
+     <p>Input's <a for=url>scheme</a> is missing, but the <a>base URL</a> has an
+     <a for=url>opaque path</a>.
+     <pre><code class=lang-javascript>
+let url = new URL("💩", "mailto:user@example.org");</code></pre>
+    </div>
+   <td>✅
+  <tr>
+   <td><dfn>relative-URL-missing-beginning-solidus</dfn>
+   <td>
+    <p>The input is a <a>relative-URL String</a> that does not begin with U+002F (/).
+    <pre class=example id=example-relative-url-missing-beginning-solidus><code class="lang-javascript">
+let url = new URL("foo.html", "https://example.org/");</code></pre>
+   <td>❌
+  <tr>
+   <td><dfn>unexpected-reverse-solidus</dfn>
+   <td>
+    <p>The URL has a <a>special scheme</a> and it uses U+005C (\) instead of U+002F (/).
+    <p class=example id=example-unexpected-reverse-solidus>"<code>https://example.org\path\to\file</code>"
+   <td>❌
+  <tr>
+   <td><dfn>missing-solidus-before-authority</dfn>
+   <td>
+    <p>The URL <a>includes credentials</a> that are not preceded by "<code>//</code>".
+    <p class=example id=example-missing-solidus-before-authority>"<code>https:user@example.org</code>"
+   <td>❌
+  <tr>
+   <td><dfn>unexpected-at-sign</dfn>
+   <td>
+    <p>The URL <a>includes credentials</a>, however this is considered invalid.
+    <p class=example id=example-unexpected-at-sign>"<code>https://user@example.org</code>"
+   <td>❌
+  <tr>
+   <td><dfn>unexpected-credentials-without-host</dfn>
+   <td>
+    <p>The URL <a>include credentials</a>, but no <a for=url>host</a>.
+    <p class=example id=example-unexpected-credentials-without-host>"<code>https://user:pass@</code>"
+   <td>✅
+  <tr>
+   <td><dfn>unexpected-port-without-host</dfn>
+   <td>
+    <p>The URL contains a <a for=url>port</a>, but no <a for=url>host</a>.
+    <p class=example id=example-unexpected-port-without-host>"<code>https://:443</code>"
+   <td>✅
+  <tr>
+   <td><dfn>empty-host-special-scheme</dfn>
+   <td>
+    <p>The URL has a <a>special scheme</a>, but does not contain a <a for=url>host</a>.
+    <p class=example id=example-empty-host-special-scheme>"<code>https://#fragment</code>"
+   <td>✅
+  <tr>
+   <td><dfn>host-invalid</dfn>
+   <td>
+    <p>The <a for=url>host</a> portion of the URL is an empty string when it
+    <a>includes credentials</a> or a <a>port</a> and the <a>basic URL parser</a>'s state is
+    overridden.
+    <pre class=example id=example-host-invalid><code class=lang-javascript>
+const url = new URL("https://example:9000");
+url.hostname = "";</code></pre>
+   <td>❌
+  <tr>
+   <td><dfn>port-out-of-range</dfn>
+   <td>
+    <p>The input's port is too big.
+    <p class=example id=example-port-out-of-range>"<code>https://example.org:70000</code>"
+   <td>✅
+  <tr>
+   <td><dfn>port-invalid</dfn>
+   <td>
+    <p>The input's port is invalid.
+    <p class=example id=example-port-invalid>"<code>https://example.org:7z</code>"
+   <td>✅
+  <tr>
+   <td><dfn>unexpected-Windows-drive-letter</dfn>
+   <td>
+    <p>The input is a <a>relative-URL string</a> that <a>starts with a Windows drive letter</a> and
+    the <a>base URL</a>'s <a for=url>scheme</a> is "<code>file</code>".
+    <pre class=example id=example-unexpected-windows-drive-letter><code class=lang-javascript>
+let url = new URL("/c:/path/to/file", "file:///c:/");</code></pre>
+   <td>❌
+  <tr>
+   <td><dfn>unexpected-Windows-drive-letter-host</dfn>
+   <td>
+    <p>The file URL's host is a Windows drive letter.
+    <p class=example id=example-unexpected-windows-drive-letter-host>"<code>file://c:</code>"
+   <td>❌
+  <tr>
+   <td><dfn>invalid-URL-code-point</dfn>
+   <td>
+    <p>A code point is found that is not a <a>URL code point</a> or U+0025 (%), in the URL's
+    <a for=url>path</a>, <a for=url>query</a>, or <a for=url>fragment</a>.
+    <p class=example id=example-invalid-url-code-point>"<code>https://example.org/></code>"
+   <td>❌
+  <tr>
+   <td><dfn>unescaped-percent-sign</dfn>
+   <td>
+    <p>A U+0025 (%) is found that is not followed by two <a>ASCII hex digits</a>, in the URL's
+    <a for=url>path</a>, <a for=url>query</a>, or <a for=url>fragment</a>.
+    <p class=example id=example-unescaped-percent-sign>"<code>https://example.org/%s</code>"
+   <td>❌
+  <tr>
+   <td><dfn>unclosed-IPv6-address</dfn>
+   <td>
+    <p>An IPv6 address is missing the closing U+005D (]).
+    <p class=example id=example-unclosed-ipv6-address>"<code>https://[::1</code>"
+   <td>✅
+  <tr>
+   <td><dfn id=validation-error-domain-to-ascii>domain-to-ASCII</dfn>
+   <td>
+    <p>The result of <a abstract-op lt=ToASCII>Unicode toASCII</a> records an error while processing
+    the input domain.
+    <p class=note>[[!UTS46]] conformance does not require the reporting of precise errors, only that
+    an error has occurred. If the [[!UTS46]] implementation reports precise error codes, user agents
+    are encouraged pass those codes along.
+   <td>✅
+  <tr>
+   <td><dfn>domain-to-ASCII-empty</dfn>
+   <td>
+    <p>The result of <a abstract-op lt=ToASCII>Unicode toASCII</a> returns an empty string. This
+    could have been caused by:
+    <ul>
+     <li>Input consists of all ignorable code points.
+     <li>Input is the string "<code>xn--</code>".
+     <li>Input is the empty string and the <i>VerifyDnsLength</i> parameter is false.
+    </ul>
+   <td>✅
+  <tr>
+   <td><dfn>domain-to-Unicode</dfn>
+   <td>
+    <p>The result of <a abstract-op lt=ToUnicode>Unicode toUnicode</a> returns an error while
+    processing the input domain.
+    <p class=note>The same considerations as with <a>domain-to-ASCII</a> apply.
+   <td>❌
+  <tr>
+   <td><dfn id=validation-error-forbidden-domain-code-point>forbidden-domain-code-point</dfn>
+   <td>
+    <p>The input's host contains a <a>forbidden domain code point</a>.
+    <div class=example id=example-forbidden-domain-code-point>
+     <p>Hosts are <a for=string>percent-decoded</a> before being processed when the URL
+     <a>is special</a>, which would result in the following host portion becoming
+     "<code>exa#mple.org</code>".
+     <p>"<code>https://exa%23mple.org</code>"
+    </div>
+   <td>✅
+  <tr>
+   <td><dfn>unexpected-non-decimal-number</dfn>
+   <td>
+    <p>The IPv4 address contains numbers expressed using hexadecimal or octal digits.
+    <p class=example id=example-unexpected-non-decimal-number>"<code>https://127.0.0x0.1</code>"
+   <td>❌
+  <tr>
+   <td><dfn>IPv4-part-out-of-range</dfn>
+   <td>
+    <p>An IPv4 part exceeds 255. This is only fatal if the last part exceeds 255.
+    <p class=example id=example-ipv4-part-out-of-range>"<code>https://255.255.4000.1</code>"
+   <td>✅
+  <tr>
+   <td><dfn>invalid-compressed-IPv6-address</dfn>
+   <td>
+    <p>An IPv6 address begins with improper compression.
+    <p class=example id=example-invalid-compressed-ipv6-address>"<code>https://[:1]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv6-too-many-pieces</dfn>
+   <td>
+    <p>An IPv6 address contains more than 8 pieces.
+    <p class=example id=example-ipv6-too-many-pieces>"<code>https://[1:2:3:4:5:6:7:8:9]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv6-multiple-compression</dfn>
+   <td>
+    <p>An IPv6 address is compressed in more than one spot.
+    <p class=example id=example-ipv6-multiple-compression>"<code>https://[1::1::1]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-empty-part</dfn>
+   <td>
+    <p>An IPv6 address that contains an IPv4 address has an empty part in the IPv4 address.
+    <p class=example id=example-ipv4-in-ipv6-empty-part>"<code>https://[ffff::.0.0.1]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-too-many-pieces</dfn>
+   <td>
+    <p>An IPv6 address contains an IPv4 address and the IPv6 address has more than 6 pieces.
+    <p class=example id=example-ipv4-in-ipv6-too-many-pieces>"<code>https://[1:1:1:1:1:1:1:127.0.0.1]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv6-unexpected-eof</dfn>
+   <td>
+    <p>An IPv6 address unexpectedly ends.
+    <p class=example id=example-ipv6-unexpected-eof>"<code>https://[1:2:3:]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv6-unexpected-delimiter</dfn>
+   <td>
+    <p>An IPv6 address contains a code point that is neither an <a>ASCII hex digit</a> nor a
+    U+003A (:).
+    <p class=example id=example-ipv6-unexpected-delimiter>"<code>https://[1:2:3!:4]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv6-too-few-pieces</dfn>
+   <td>
+    <p>An uncompressed IPv6 address contains fewer than 8 pieces.
+    <p class=example id=example-ipv6-too-few-pieces>"<code>https://[1:2:3]</code>"
+   <td>✅
+  <tr>
+   <td><dfn id=validation-error-forbidden-host-code-point>forbidden-host-code-point</dfn>
+   <td>
+    <p>When an <a>opaque host</a> (in a URL that <a>is not special</a>) contains a
+    <a>forbidden host code point</a>.
+   <p class=example id=example-forbidden-host-code-point>"<code>foo://exa[mple.org</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-too-many-parts</dfn>
+   <td>
+    <p>An IPv6 address contains an IPv4 address and the IPv4 address has more than 4 parts.
+    <p class=example id=example-ipv4-in-ipv6-too-many-parts>"<code>https://[ffff::127.0.0.1.2]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-unexpected-code-point</dfn>
+   <td>
+    <p>An IPv6 address contains an IPv4 address of which a part contain a code point other than an
+    <a>ASCII digits</a> or is the empty string.
+    <p class=example id=example-ipv4-in-ipv6-unexpected-code-point>"<code>https://[ffff::127.0.xyz.1]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-invalid-first-part</dfn>
+   <td>
+    <p>The first part of an IPv4 address that is contained within an IPv6 address is 0.
+    <p class=example id=example-ipv4-in-ipv6-invalid-first-part>"<code>https://[ffff::0.0.0.1]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-part-out-of-range</dfn>
+   <td>
+    <p>An IPv4 address contained within an IPv6 address contains a part that exceeds 255.
+    <p class=example id=example-ipv4-in-ipv6-part-out-of-range>"<code>https://[ffff::127.0.0.4000]</code>"
+   <td>✅
+  <tr>
+   <td><dfn>IPv4-in-IPv6-too-few-parts</dfn>
+   <td>
+    <p>An IPv4 address contained within an IPv6 address does not contain exactly 4 parts.
+    <p class=example id=example-ipv4-in-ipv6-too-few-parts>"<code>https://[ffff::127.0.0]</code>"
+   <td>✅
+</table>
+
 
 <h3 id=parsers>Parsers</h3>
 
@@ -653,9 +948,11 @@ concepts.
   <a for=list>item</a> that <a for=string>starts with</a> an <a>ASCII case-insensitive</a> match for
   "<code>xn--</code>", this step is equivalent to <a>ASCII lowercasing</a> <var>domain</var>.
 
- <li><p>If <var>result</var> is a failure value, <a>validation error</a>, return failure.
+ <li><p>If <var>result</var> is a failure value, <a>domain-to-ASCII</a> <a>validation error</a>,
+ return failure.
 
- <li><p>If <var>result</var> is the empty string, <a>validation error</a>, return failure.
+ <li><p>If <var>result</var> is the empty string, <a>domain-to-ASCII-empty</a>
+ <a>validation error</a>, return failure.
 
  <li><p>Return <var>result</var>.
 </ol>
@@ -674,8 +971,8 @@ concepts.
  <i>UseSTD3ASCIIRules</i> set to <var>beStrict</var>, and <i>Transitional_Processing</i> set to
  false. [[!UTS46]]
 
- <li><p>Signify <a>validation errors</a> for any returned errors, and then, return
- <var>result</var>.
+ <li><p>Signify <a>domain-to-Unicode</a> <a>validation errors</a> for any returned errors, and then,
+ return <var>result</var>.
 </ol>
 
 
@@ -743,7 +1040,8 @@ to be distinguished.
   <p>If <var>input</var> starts with U+005B ([), then:
 
   <ol>
-   <li><p>If <var>input</var> does not end with U+005D (]), <a>validation error</a>, return failure.
+   <li><p>If <var>input</var> does not end with U+005D (]), <a>unclosed-IPv6-address</a>
+   <a>validation error</a>, return failure.
 
    <li><p>Return the result of <a lt="IPv6 parser">IPv6 parsing</a> <var>input</var> with its
    leading U+005B ([) and trailing U+005D (]) removed.
@@ -764,10 +1062,10 @@ to be distinguished.
  <li><p>Let <var>asciiDomain</var> be the result of running <a>domain to ASCII</a> with
  <var>domain</var> and false.
 
- <li><p>If <var>asciiDomain</var> is failure, <a>validation error</a>, return failure.
+ <li><p>If <var>asciiDomain</var> is failure, then return failure.
 
  <li><p>If <var>asciiDomain</var> contains a <a>forbidden domain code point</a>,
- <a>validation error</a>, return failure.
+ <a>forbidden-domain-code-point</a> <a>validation error</a>, return failure.
 
  <li><p>If <var>asciiDomain</var> <a lt="ends in a number checker">ends in a number</a>, then return
  the result of <a lt="IPv4 parser">IPv4 parsing</a> <var>asciiDomain</var>.
@@ -851,19 +1149,21 @@ return value of the <a for=/>host parser</a> is an <a for=/>IPv4 address</a>.
 
    <li><p>If <var>result</var> is failure, <a>validation error</a>, return failure.
 
-   <li><p>If <var>result</var>[1] is true, <a>validation error</a>.
+   <li><p>If <var>result</var>[1] is true, <a>unexpected-non-decimal-number</a>
+   <a>validation error</a>.
 
    <li><p><a for=list>Append</a> <var>result</var>[0] to <var>numbers</var>.
   </ol>
 
- <li><p>If any item in <var>numbers</var> is greater than 255, <a>validation error</a>.
+ <li><p>If any item in <var>numbers</var> is greater than 255, <a>IPv4-part-out-of-range</a>
+ <a>validation error</a>.
 
  <li><p>If any but the last <a for=list>item</a> in <var>numbers</var> is greater than 255, then
  return failure.
 
  <li><p>If the last <a for=list>item</a> in <var>numbers</var> is greater than or equal to
- 256<sup>(5 &minus; <var>numbers</var>'s <a for=list>size</a>)</sup>, <a>validation error</a>,
- return failure.
+ 256<sup>(5 &minus; <var>numbers</var>'s <a for=list>size</a>)</sup>,
+ <a>IPv4-part-out-of-range</a> <a>validation error</a>, return failure.
 
  <li><p>Let <var>ipv4</var> be the last <a for=list>item</a> in <var>numbers</var>.
 
@@ -960,8 +1260,8 @@ actually doing that with the editors of this document first.
   <p>If <a>c</a> is U+003A (:), then:
 
   <ol>
-   <li><p>If <a>remaining</a> does not start with U+003A (:), <a>validation error</a>, return
-   failure.
+   <li><p>If <a>remaining</a> does not start with U+003A (:),
+   <a>invalid-compressed-IPv6-address</a> <a>validation error</a>, return failure.
 
    <li><p>Increase <var>pointer</var> by 2.
 
@@ -973,13 +1273,15 @@ actually doing that with the editors of this document first.
   <p>While <a>c</a> is not the <a>EOF code point</a>:
 
   <ol>
-   <li><p>If <var>pieceIndex</var> is 8, <a>validation error</a>, return failure.
+   <li><p>If <var>pieceIndex</var> is 8, <a>IPv6-too-many-pieces</a> <a>validation error</a>, return
+   failure.
 
    <li>
     <p>If <a>c</a> is U+003A (:), then:
 
     <ol>
-     <li><p>If <var>compress</var> is non-null, <a>validation error</a>, return failure.
+     <li><p>If <var>compress</var> is non-null, <a>IPv6-multiple-compression</a>
+     <a>validation error</a>, return failure.
 
      <li>Increase <var>pointer</var> and <var>pieceIndex</var> by 1, set <var>compress</var> to
      <var>pieceIndex</var>, and then <a for=iteration>continue</a>.
@@ -995,11 +1297,13 @@ actually doing that with the editors of this document first.
     <p>If <a>c</a> is U+002E (.), then:
 
     <ol>
-     <li><p>If <var>length</var> is 0, <a>validation error</a>, return failure.
+     <li><p>If <var>length</var> is 0, <a>IPv4-in-IPv6-empty-part</a> <a>validation error</a>,
+     return failure.
 
      <li><p>Decrease <var>pointer</var> by <var>length</var>.
 
-     <li><p>If <var>pieceIndex</var> is greater than 6, <a>validation error</a>, return failure.
+     <li><p>If <var>pieceIndex</var> is greater than 6, <a>IPv4-in-IPv6-too-many-pieces</a>
+     <a>validation error</a>, return failure.
 
      <li><p>Let <var>numbersSeen</var> be 0.
 
@@ -1016,10 +1320,11 @@ actually doing that with the editors of this document first.
          <li><p>If <a>c</a> is a U+002E (.) and <var>numbersSeen</var> is less than 4, then increase
          <var>pointer</var> by 1.
 
-         <li>Otherwise, <a>validation error</a>, return failure.
+         <li>Otherwise, <a>IPv4-in-IPv6-too-many-parts</a> <a>validation error</a>, return failure.
         </ol>
 
-       <li><p>If <a>c</a> is not an <a>ASCII digit</a>, <a>validation error</a>, return failure.
+       <li><p>If <a>c</a> is not an <a>ASCII digit</a>, <a>IPv4-in-IPv6-unexpected-code-point</a>
+       <a>validation error</a>, return failure.
        <!-- prevent the empty string -->
 
        <li>
@@ -1031,13 +1336,14 @@ actually doing that with the editors of this document first.
          <li>
           <p>If <var>ipv4Piece</var> is null, then set <var>ipv4Piece</var> to <var>number</var>.
 
-          <p>Otherwise, if <var>ipv4Piece</var> is 0, <a>validation error</a>, return failure.
+          <p>Otherwise, if <var>ipv4Piece</var> is 0, <a>IPv4-in-IPv6-invalid-first-part</a>
+          <a>validation error</a>, return failure.
 
           <p>Otherwise, set <var>ipv4Piece</var> to <var>ipv4Piece</var> &times; 10 +
           <var>number</var>.
 
-         <li><p>If <var>ipv4Piece</var> is greater than 255, <a>validation error</a>, return
-         failure.
+         <li><p>If <var>ipv4Piece</var> is greater than 255, <a>IPv4-in-IPv6-part-out-of-range</a>
+         <a>validation error</a>, return failure.
 
          <li><p>Increase <var>pointer</var> by 1.
         </ol>
@@ -1050,7 +1356,8 @@ actually doing that with the editors of this document first.
        <li><p>If <var>numbersSeen</var> is 2 or 4, then increase <var>pieceIndex</var> by 1.
       </ol>
 
-     <li><p>If <var>numbersSeen</var> is not 4, <a>validation error</a>, return failure.
+     <li><p>If <var>numbersSeen</var> is not 4, <a>IPv4-in-IPv6-too-few-parts</a>
+     <a>validation error</a>, return failure.
 
      <li><p><a for=iteration>Break</a>.
     </ol>
@@ -1061,11 +1368,12 @@ actually doing that with the editors of this document first.
     <ol>
      <li><p>Increase <var>pointer</var> by 1.
 
-     <li><p>If <a>c</a> is the <a>EOF code point</a>, <a>validation error</a>, return failure.
+     <li><p>If <a>c</a> is the <a>EOF code point</a>, <a>IPv6-unexpected-eof</a>
+     <a>validation error</a>, return failure.
     </ol>
 
-   <li><p>Otherwise, if <a>c</a> is not the <a>EOF code point</a>, <a>validation error</a>, return
-   failure.
+   <li><p>Otherwise, if <a>c</a> is not the <a>EOF code point</a>, <a>IPv6-unexpected-delimiter</a>
+   <a>validation error</a>, return failure.
 
    <li><p>Set <var>address</var>[<var>pieceIndex</var>] to <var>value</var>.
 
@@ -1087,7 +1395,7 @@ actually doing that with the editors of this document first.
   </ol>
 
  <li><p>Otherwise, if <var>compress</var> is null and <var>pieceIndex</var> is not 8,
- <a>validation error</a>, return failure.
+ <a>IPv6-too-few-pieces</a> <a>validation error</a>, return failure.
 
  <li><p>Return <var>address</var>.
 </ol>
@@ -1102,13 +1410,13 @@ actually doing that with the editors of this document first.
 
 <ol>
  <li><p>If <var>input</var> contains a <a>forbidden host code point</a>,
- <a>validation error</a>, return failure.
+ <a>forbidden-host-code-point</a> <a>validation error</a>, return failure.
 
  <li><p>If <var>input</var> contains a <a>code point</a> that is not a <a>URL code point</a> and not
- U+0025 (%), <a>validation error</a>.
+ U+0025 (%), <a>invalid-URL-code-point</a> <a>validation error</a>.
 
  <li><p>If <var>input</var> contains a U+0025 (%) and the two <a>code points</a> following it are
- not <a>ASCII hex digits</a>, <a>validation error</a>.
+ not <a>ASCII hex digits</a>, <a>unescaped-percent-sign</a> <a>validation error</a>.
 
  <li><p>Return the result of running <a for=string>UTF-8 percent-encode</a> on <var>input</var>
  using the <a>C0 control percent-encode set</a>.
@@ -1853,12 +2161,13 @@ and then runs these steps:
    <li><p>Set <var>url</var> to a new <a for=/>URL</a>.
 
    <li><p>If <var>input</var> contains any leading or trailing <a>C0 control or space</a>,
-   <a>validation error</a>.
+   <a>unexpected-C0-control-or-space</a> <a>validation error</a>.
 
    <li><p>Remove any leading and trailing <a>C0 control or space</a> from <var>input</var>.
   </ol>
 
- <li><p>If <var>input</var> contains any <a>ASCII tab or newline</a>, <a>validation error</a>.
+ <li><p>If <var>input</var> contains any <a>ASCII tab or newline</a>,
+ <a>unexpected-ASCII-tab-or-newline</a> <a>validation error</a>.
 
  <li><p>Remove all <a>ASCII tab or newline</a> from <var>input</var>.
 
@@ -1892,7 +2201,7 @@ and then runs these steps:
      <a>no scheme state</a> and decrease <var>pointer</var> by 1.
 
      <li>
-      <p>Otherwise, <a>validation error</a>, return failure.
+      <p>Otherwise, <a>invalid-scheme-start</a> <a>validation error</a>, return failure.
 
       <p class=note>This indication of failure is used exclusively by the {{Location}} object's
       {{Location/protocol}} setter.
@@ -1944,7 +2253,7 @@ and then runs these steps:
 
         <ol>
          <li><p>If <a>remaining</a> does not start with "<code>//</code>",
-         <a>validation error</a>.
+         <a>file-scheme-missing-following-solidus</a> <a>validation error</a>.
 
          <li><p>Set <var>state</var> to <a>file state</a>.
         </ol>
@@ -1976,7 +2285,7 @@ and then runs these steps:
      in <var>input</var>).
 
      <li>
-      <p>Otherwise, <a>validation error</a>, return failure.
+      <p>Otherwise, <a>invalid-scheme</a> <a>validation error</a>, return failure.
 
       <p class=note>This indication of failure is used exclusively by the {{Location}} object's
       {{Location/protocol}} setter. Furthermore, the non-failure termination earlier in this state
@@ -1987,7 +2296,8 @@ and then runs these steps:
    <dd>
     <ol>
      <li><p>If <var>base</var> is null, or <var>base</var> has an <a for=url>opaque path</a> and
-     <a>c</a> is not U+0023 (#), <a>validation error</a>, return failure.
+     <a>c</a> is not U+0023 (#), <a>missing-scheme-non-relative-URL</a> <a>validation error</a>,
+     return failure.
 
      <li><p>Otherwise, if <var>base</var> has an <a for=url>opaque path</a> and <a>c</a> is
      U+0023 (#), set <var>url</var>'s <a for=url>scheme</a> to
@@ -2013,8 +2323,8 @@ and then runs these steps:
      <var>state</var> to <a>special authority ignore slashes state</a> and increase
      <var>pointer</var> by 1.
 
-     <li><p>Otherwise, <a>validation error</a>, set <var>state</var> to <a>relative state</a> and
-     decrease <var>pointer</var> by 1.
+     <li><p>Otherwise, <a>relative-URL-missing-beginning-solidus</a> <a>validation error</a>, set
+     <var>state</var> to <a>relative state</a> and decrease <var>pointer</var> by 1.
     </ol>
 
    <dt><dfn export for="basic URL parser" id=path-or-authority-state>path or authority state</dfn>
@@ -2036,7 +2346,8 @@ and then runs these steps:
      <li><p>If <a>c</a> is U+002F (/), then set <var>state</var> to <a>relative slash state</a>.
 
      <li><p>Otherwise, if <var>url</var> <a>is special</a> and <a>c</a> is U+005C (\),
-     <a>validation error</a>, set <var>state</var> to <a>relative slash state</a>.
+     <a>unexpected-reverse-solidus</a> <a>validation error</a>, set <var>state</var> to
+     <a>relative slash state</a>.
 
      <li>
       <p>Otherwise:
@@ -2081,7 +2392,8 @@ and then runs these steps:
       <p>If <var>url</var> <a>is special</a> and <a>c</a> is U+002F (/) or U+005C (\), then:
 
       <ol>
-       <li><p>If <a>c</a> is U+005C (\), <a>validation error</a>.
+       <li><p>If <a>c</a> is U+005C (\), <a>unexpected-reverse-solidus</a>
+       <a>validation error</a>.
 
        <li><p>Set <var>state</var> to <a>special authority ignore slashes state</a>.
       </ol>
@@ -2108,8 +2420,9 @@ and then runs these steps:
      <var>state</var> to <a>special authority ignore slashes state</a> and increase
      <var>pointer</var> by 1.
 
-     <li><p>Otherwise, <a>validation error</a>, set <var>state</var> to
-     <a>special authority ignore slashes state</a> and decrease <var>pointer</var> by 1.
+     <li><p>Otherwise, <a>missing-solidus-before-authority</a> <a>validation error</a>, set
+     <var>state</var> to <a>special authority ignore slashes state</a> and decrease
+     <var>pointer</var> by 1.
     </ol>
 
    <dt><dfn export for="basic URL parser" id=special-authority-ignore-slashes-state>special authority ignore slashes state</dfn>
@@ -2118,7 +2431,7 @@ and then runs these steps:
      <li><p>If <a>c</a> is neither U+002F (/) nor U+005C (\), then set <var>state</var> to
      <a>authority state</a> and decrease <var>pointer</var> by 1.
 
-     <li><p>Otherwise, <a>validation error</a>.
+     <li><p>Otherwise, <a>missing-solidus-before-authority</a> <a>validation error</a>.
     </ol>
 
    <dt><dfn export for="basic URL parser" id=authority-state>authority state</dfn>
@@ -2128,7 +2441,7 @@ and then runs these steps:
       <p>If <a>c</a> is U+0040 (@), then:
 
       <ol>
-       <li><p><a>Validation error</a>.
+       <li><p><a>Unexpected-at-sign</a> <a>validation error</a>.
 
        <li><p>If <var>atSignSeen</var> is true, then prepend "<code>%40</code>" to
        <var>buffer</var>.
@@ -2168,7 +2481,7 @@ and then runs these steps:
 
       <ol>
        <li><p>If <var>atSignSeen</var> is true and <var>buffer</var> is the empty string,
-       <a>validation error</a>, return failure.
+       <a>unexpected-credentials-without-host</a> <a>validation error</a>, return failure.
        <!-- No URLs with userinfo, but without host. For special URLs it would also not be
             idempotent:
             https://@/example.org/ -> https:///example.org/ -> https://example.org/ -->
@@ -2193,7 +2506,8 @@ and then runs these steps:
       <p>Otherwise, if <a>c</a> is U+003A (:) and <var>insideBrackets</var> is false, then:
 
       <ol>
-       <li><p>If <var>buffer</var> is the empty string, <a>validation error</a>, return failure.
+       <li><p>If <var>buffer</var> is the empty string, <a>unexpected-port-without-host</a>
+       <a>validation error</a>, return failure.
        <!-- No URLs with port, but without host. -->
 
        <li><p>If <var>state override</var> is given and <var>state override</var> is
@@ -2221,13 +2535,13 @@ and then runs these steps:
 
       <ol>
        <li><p>If <var>url</var> <a>is special</a> and <var>buffer</var> is the empty string,
-       <a>validation error</a>, return failure.
+       <a>empty-host-special-scheme</a> <a>validation error</a>, return failure.
        <!-- http://? -> failure
             test://? -> test://? -->
 
        <li><p>Otherwise, if <var>state override</var> is given, <var>buffer</var> is the empty
        string, and either <var>url</var> <a>includes credentials</a> or <var>url</var>'s
-       <a for=url>port</a> is non-null, return.
+       <a for=url>port</a> is non-null, <a>host-invalid</a> <a>validation error</a>, return.
 
        <li><p>Let <var>host</var> be the result of <a>host parsing</a> <var>buffer</var> with
        <var>url</var> <a>is not special</a>.
@@ -2279,7 +2593,7 @@ and then runs these steps:
          0 through 9.
 
          <li><p>If <var>port</var> is greater than 2<sup>16</sup>&nbsp;&minus;&nbsp;1,
-         <a>validation error</a>, return failure.
+         <a>port-out-of-range</a> <a>validation error</a>, return failure.
 
          <li><p>Set <var>url</var>'s <a for=url>port</a> to null, if <var>port</var> is
          <var>url</var>'s <a for=url>scheme</a>'s <a>default port</a>; otherwise to <var>port</var>.
@@ -2292,7 +2606,7 @@ and then runs these steps:
        <li><p>Set <var>state</var> to <a>path start state</a> and decrease <var>pointer</var> by 1.
       </ol>
 
-     <li><p>Otherwise, <a>validation error</a>, return failure.
+     <li><p>Otherwise, <a>port-invalid</a> <a>validation error</a>, return failure.
     </ol>
 
    <dt><dfn export for="basic URL parser" id=file-state>file state</dfn>
@@ -2306,7 +2620,7 @@ and then runs these steps:
       <p>If <a>c</a> is U+002F (/) or U+005C (\), then:
 
       <ol>
-       <li><p>If <a>c</a> is U+005C (\), <a>validation error</a>.
+       <li><p>If <a>c</a> is U+005C (\), <a>unexpected-reverse-solidus</a> <a>validation error</a>.
 
        <li><p>Set <var>state</var> to <a>file slash state</a>.
       </ol>
@@ -2343,7 +2657,7 @@ and then runs these steps:
           <p>Otherwise:
 
           <ol>
-           <li><p><a>Validation error</a>.
+           <li><p><a>Unexpected-Windows-drive-letter</a> <a>validation error</a>.
 
            <li><p>Set <var>url</var>'s <a for=url>path</a> to « ».
           </ol>
@@ -2365,7 +2679,7 @@ and then runs these steps:
       <p>If <a>c</a> is U+002F (/) or U+005C (\), then:
 
       <ol>
-       <li><p>If <a>c</a> is U+005C (\), <a>validation error</a>.
+       <li><p>If <a>c</a> is U+005C (\), <a>unexpected-reverse-solidus</a> <a>validation error</a>.
 
        <li><p>Set <var>state</var> to <a>file host state</a>.
       </ol>
@@ -2406,8 +2720,8 @@ and then runs these steps:
       <ol>
        <li>
         <p>If <var>state override</var> is not given and <var>buffer</var> is a
-        <a>Windows drive letter</a>, <a>validation error</a>, set <var>state</var> to
-        <a>path state</a>.
+        <a>Windows drive letter</a>, <a>unexpected-Windows-drive-letter-host</a>
+        <a>validation error</a>, set <var>state</var> to <a>path state</a>.
 
         <p class=note>This is a (platform-independent) Windows drive letter quirk. <var>buffer</var>
         is not reset here and instead used in the <a>path state</a>.
@@ -2454,7 +2768,7 @@ and then runs these steps:
       <p>If <var>url</var> <a>is special</a>, then:
 
       <ol>
-       <li><p>If <a>c</a> is U+005C (\), <a>validation error</a>.
+       <li><p>If <a>c</a> is U+005C (\), <a>unexpected-reverse-solidus</a> <a>validation error</a>.
 
        <li><p>Set <var>state</var> to <a>path state</a>.
 
@@ -2500,7 +2814,7 @@ and then runs these steps:
 
       <ol>
        <li><p>If <var>url</var> <a>is special</a> and <a>c</a> is U+005C (\),
-       <a>validation error</a>.
+       <a>unexpected-reverse-solidus</a> <a>validation error</a>.
 
        <li>
         <p>If <var>buffer</var> is a <a>double-dot URL path segment</a>, then:
@@ -2550,10 +2864,10 @@ and then runs these steps:
 
       <ol>
        <li><p>If <a>c</a> is not a <a>URL code point</a> and not U+0025 (%),
-       <a>validation error</a>.
+       <a>invalid-URL-code-point</a> <a>validation error</a>.
 
        <li><p>If <a>c</a> is U+0025 (%) and <a>remaining</a> does not start with two
-       <a>ASCII hex digits</a>, <a>validation error</a>.
+       <a>ASCII hex digits</a>, <a>unescaped-percent-sign</a> <a>validation error</a>.
 
        <li><p><a for="code point">UTF-8 percent-encode</a> <a>c</a> using the
        <a>path percent-encode set</a> and append the result to <var>buffer</var>.
@@ -2574,10 +2888,10 @@ and then runs these steps:
 
       <ol>
        <li><p>If <a>c</a> is not the <a>EOF code point</a>, not a <a>URL code point</a>, and not
-       U+0025 (%), <a>validation error</a>.
+       U+0025 (%), <a>invalid-URL-code-point</a> <a>validation error</a>.
 
        <li><p>If <a>c</a> is U+0025 (%) and <a>remaining</a> does not start with two
-       <a>ASCII hex digits</a>, <a>validation error</a>.
+       <a>ASCII hex digits</a>, <a>unescaped-percent-sign</a> <a>validation error</a>.
 
        <li><p>If <a>c</a> is not the <a>EOF code point</a>,
        <a for="code point">UTF-8 percent-encode</a> <a>c</a> using the
@@ -2633,10 +2947,10 @@ and then runs these steps:
 
       <ol>
        <li><p>If <a>c</a> is not a <a>URL code point</a> and not U+0025 (%),
-       <a>validation error</a>.
+       <a>invalid-URL-code-point</a> <a>validation error</a>.
 
        <li><p>If <a>c</a> is U+0025 (%) and <a>remaining</a> does not start with two
-       <a>ASCII hex digits</a>, <a>validation error</a>.
+       <a>ASCII hex digits</a>, <a>unescaped-percent-sign</a> <a>validation error</a>.
 
        <li><p>Append <a>c</a> to <var>buffer</var>.
       </ol>
@@ -2650,10 +2964,10 @@ and then runs these steps:
 
       <ol>
        <li><p>If <a>c</a> is not a <a>URL code point</a> and not U+0025 (%),
-       <a>validation error</a>.
+       <a>invalid-URL-code-point</a> <a>validation error</a>.
 
        <li><p>If <a>c</a> is U+0025 (%) and <a>remaining</a> does not start with two
-       <a>ASCII hex digits</a>, <a>validation error</a>.
+       <a>ASCII hex digits</a>, <a>unescaped-percent-sign</a> <a>validation error</a>.
 
        <li><p><a for="code point">UTF-8 percent-encode</a> <a>c</a> using the
        <a>fragment percent-encode set</a> and append the result to <var>url</var>'s

--- a/url.bs
+++ b/url.bs
@@ -1342,7 +1342,7 @@ actually doing that with the editors of this document first.
           <p>Otherwise, set <var>ipv4Piece</var> to <var>ipv4Piece</var> &times; 10 +
           <var>number</var>.
 
-         <li><p>If <var>ipv4Piece</var> is greater than 255, <a>IPv4-in-IPv6-part-out-of-range</a>
+         <li><p>If <var>ipv4Piece</var> is greater than 255, <a>IPv4-in-IPv6-out-of-range-part</a>
          <a>validation error</a>, return failure.
 
          <li><p>Increase <var>pointer</var> by 1.


### PR DESCRIPTION
This addresses #406. 

By my count, there are 54 different places where a `validation error` can occur with the majority of them being unique. This adds a table with descriptive error codes for each unique validation error, which also has an associated description of the error. 

- Would there by value in adding a column indicating whether the validation error can cause the parser to fail?
- I am considering adding example input that would trigger each validation error. Is this something you think would have value?
- The `unexpected-windows-drive-letter-host` needs an error description still.
- I wasn't sure how best to link the validation errors in each spot, so I just ended up doing `<a><unique error name></a> <a>validation error</a>` everywhere. I had considered a prefix or suffix of `validation-error` to every code, but felt it was overly verbose, though I'm not opposed to it if someone feels its more appropriate.
- "Error Message" should probably be renamed to "Error Description".
- Some of the error descriptions could probably use a little more detail, but I wanted to get this initial draft posted.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/502.html" title="Last updated on Feb 17, 2023, 11:08 AM UTC (1fddbe3)">Preview</a> | <a href="https://whatpr.org/url/502/8653878...1fddbe3.html" title="Last updated on Feb 17, 2023, 11:08 AM UTC (1fddbe3)">Diff</a>