### PR TITLE
Non-special URLs were not idempotent

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2533,8 +2533,22 @@ then runs these steps, returning an <a>ASCII string</a>:
  <li><p>If <var>url</var>'s <a for=url>cannot-be-a-base-URL flag</a> is set, append <var>url</var>'s
  <a for=url>path</a>[0] to <var>output</var>.
 
- <li><p>Otherwise, then <a for=list>for each</a> string in <var>url</var>'s <a for=url>path</a>,
- append U+002F (/) followed by the string to <var>output</var>.
+ <li>
+  <p>Otherwise:
+
+  <ol>
+   <li><p>If <var>url</var>'s <a for=url>host</a> is null, <var>url</var>'s <a for=url>path</a>'s
+   <a for=list>size</a> is greater than 1, and <var>url</var>'s <a for=url>path</a>[0] is the empty
+   string, then append U+002F (/) followed by U+002E (.) to <var>output</var>.
+
+   <li><p><a for=list>For each</a> <var>segment</var> of <var>url</var>'s <a for=url>path</a>:
+   append U+002F (/) followed by <var>segment</var> to <var>output</var>.
+  </ol>
+
+  <p class=note>This prevents <code>web+demo:/.//not-a-host/</code> or
+  <code>web+demo:/path/..//not-a-host/</code>, when <a lt="URL parser">parsed</a> and then
+  <a lt="URL serializer">serialized</a>, from ending up as <code>web+demo://not-a-host/</code> (they
+  end up as <code>web+demo:/.//not-a-host/</code>).
 
  <li><p>If <var>url</var>'s <a for=url>query</a> is non-null, append
  U+003F (?), followed by <var>url</var>'s <a for=url>query</a>, to
@@ -3472,8 +3486,9 @@ Valentin Gosu,
 Vyacheslav Matva,
 Wei Wang,
 山岸和利 (Yamagishi Kazutoshi),
-Yongsheng Zhang, and
-成瀬ゆい (Yui Naruse)
+Yongsheng Zhang,
+成瀬ゆい (Yui Naruse), and
+zealousidealroll
 for being awesome!
 
 <p>This standard is written by


### PR DESCRIPTION
Adjust the URL serializer so it does not output something which during the next parse operation would yield a host.

whatwg-url: https://github.com/jsdom/whatwg-url/pull/148

Tests: ...

Fixes #415.

@zealousidealroll what do you think?

<!--
Thank you for contributing to the URL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Node.js: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/505.html" title="Last updated on Aug 23, 2020, 4:22 PM UTC (c3c7a82)">Preview</a> | <a href="https://whatpr.org/url/505/e5334dd...c3c7a82.html" title="Last updated on Aug 23, 2020, 4:22 PM UTC (c3c7a82)">Diff</a>