### PR TITLE
Define upper limit of a URL-port string

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1415,8 +1415,13 @@ switching on <a>base URL</a>'s <a for=url>scheme</a>:
 <a>valid host string</a>, optionally followed by U+003A (:) and a <a>URL-port string</a>, optionally
 followed by a <a>path-absolute-URL string</a>.
 
-<p>A <dfn export oldids=syntax-url-port>URL-port string</dfn> must be zero or more
-<a>ASCII digits</a>.
+<p>A <dfn export oldids=syntax-url-port>URL-port string</dfn> must be one of the following:
+
+<ul class=brief>
+ <li><p>the empty string
+ <li><p>one or more <a>ASCII digits</a> representing a decimal number no greater than
+ 2<sup>16</sup>&nbsp;&minus;&nbsp;1.
+</ul>
 
 <p>A <dfn export oldids=syntax-url-scheme-relative>scheme-relative-URL string</dfn> must be
 "<code>//</code>", followed by an <a>opaque-host-and-port string</a>, optionally followed by a


### PR DESCRIPTION
Spotted in https://github.com/whatwg/url/pull/502.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/519.html" title="Last updated on May 18, 2020, 9:00 AM UTC (e540eac)">Preview</a> | <a href="https://whatpr.org/url/519/cb9c97f...e540eac.html" title="Last updated on May 18, 2020, 9:00 AM UTC (e540eac)">Diff</a>