### PR TITLE
Do not return ipv4Host if IPv4 parsing fails

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -567,7 +567,7 @@ string <var>input</var> with an optional boolean <var>isNotSpecial</var>, and th
  <li><p>Let <var>ipv4Host</var> be the result of <a lt="IPv4 parser">IPv4 parsing</a>
  <var>asciiDomain</var>.
 
- <li><p>If <var>ipv4Host</var> is an <a>IPv4 address</a> or failure, return
+ <li><p>If <var>ipv4Host</var> is an <a>IPv4 address</a>, return
  <var>ipv4Host</var>.
 
  <li><p>Return <var>asciiDomain</var>.
@@ -3418,6 +3418,7 @@ Jeffrey Yasskin,
 Joe Duarte,
 Joshua Bell,
 Jxck,
+Karl Wagner,
 田村健人 (Kent TAMURA),
 Kevin Grandon,
 Kornel Lesiński,


### PR DESCRIPTION
This seems like a typo - if IPv4 parsing returns failure, we should assume the string is a domain.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 2, 2020, 1:05 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Furl%2Fc1c213322986a167ae8c49a7078f8cd9f76c3e12%2Furl.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20524)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/url%23524.)._
</details>
