### PR TITLE
Changes to file URL path normalization

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2209,6 +2209,8 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
         "<code>file</code>", then:
 
         <ol>
+         <li><p>Set <var>url</var>'s <a for=url>host</a> to <var>base</var>'s <a for=url>host</a>.
+
          <li>
           <p>If the substring from <var>pointer</var> in <var>input</var> does not
           <a>start with a Windows drive letter</a> and <var>base</var>'s <a for=url>path</a>[0] is a
@@ -2216,9 +2218,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
           <a for=url>path</a>[0] to <var>url</var>'s <a for=url>path</a>.
 
           <p class=note>This is a (platform-independent) Windows drive letter quirk.
-          <var>url</var>'s <a for=url>host</a> is null under these conditions.
 
-         <li><p>Set <var>url</var>'s <a for=url>host</a> to <var>base</var>'s <a for=url>host</a>.
         </ol>
 
        <li><p>Set <var>state</var> to <a>path state</a>, and decrease <var>pointer</var> by 1.

--- a/url.bs
+++ b/url.bs
@@ -2353,7 +2353,9 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
          <li>
           <p>If <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>", <var>url</var>'s
           <a for=url>path</a> <a for=list>is empty</a>, and <var>buffer</var> is a
-          <a>Windows drive letter</a>, then replace the second code point in <var>buffer</var> with U+003A (:).
+          <a>Windows drive letter</a>, then replace the second code point in <var>buffer</var> with
+          U+003A (:).
+
           <p class=note>This is a (platform-independent) Windows drive letter quirk.
 
          <li><p><a for=list>Append</a> <var>buffer</var> to <var>url</var>'s <a for=url>path</a>.

--- a/url.bs
+++ b/url.bs
@@ -2175,8 +2175,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
           <ol>
            <li><p><a>Validation error</a>.
 
-           <li><p>Set <var>url</var>'s <a for=url>host</a> to null and <var>url</var>'s
-           <a for=url>path</a> to an empty list.
+           <li><p>Set <var>url</var>'s <a for=url>path</a> to an empty list.
           </ol>
 
           <p class=note>This is a (platform-independent) Windows drive letter quirk.
@@ -2206,22 +2205,20 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
 
       <ol>
        <li>
-        <p>If <var>base</var> is non-null, <var>base</var>'s <a for=url>scheme</a> is
-        "<code>file</code>", and the substring from <var>pointer</var> in <var>input</var> does not
-        <a>start with a Windows drive letter</a>, then:
+        <p>If <var>base</var> is non-null and <var>base</var>'s <a for=url>scheme</a> is
+        "<code>file</code>", then:
 
         <ol>
          <li>
-          <p>If <var>base</var>'s <a for=url>path</a>[0] is a
+          <p>If the substring from <var>pointer</var> in <var>input</var> does not
+          <a>start with a Windows drive letter</a> and <var>base</var>'s <a for=url>path</a>[0] is a
           <a>normalized Windows drive letter</a>, then <a for=list>append</a> <var>base</var>'s
           <a for=url>path</a>[0] to <var>url</var>'s <a for=url>path</a>.
 
-          <p class=note>This is a (platform-independent) Windows drive letter quirk. Both
-          <var>url</var>'s and <var>base</var>'s <a for=url>host</a> are null under these conditions
-          and therefore not copied.
+          <p class=note>This is a (platform-independent) Windows drive letter quirk.
+          <var>url</var>'s <a for=url>host</a> is null under these conditions.
 
-         <li><p>Otherwise, set <var>url</var>'s <a for=url>host</a> to <var>base</var>'s
-         <a for=url>host</a>.
+         <li><p>Set <var>url</var>'s <a for=url>host</a> to <var>base</var>'s <a for=url>host</a>.
         </ol>
 
        <li><p>Set <var>state</var> to <a>path state</a>, and decrease <var>pointer</var> by 1.
@@ -2356,27 +2353,13 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
          <li>
           <p>If <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>", <var>url</var>'s
           <a for=url>path</a> <a for=list>is empty</a>, and <var>buffer</var> is a
-          <a>Windows drive letter</a>, then:
-
-          <ol>
-           <li><p>If <var>url</var>'s <a for=url>host</a> is neither the empty string nor null,
-           <a>validation error</a>, set <var>url</var>'s <a for=url>host</a> to the empty string.
-
-           <li><p>Replace the second code point in <var>buffer</var> with U+003A (:).
-          </ol>
-
+          <a>Windows drive letter</a>, then replace the second code point in <var>buffer</var> with U+003A (:).
           <p class=note>This is a (platform-independent) Windows drive letter quirk.
 
          <li><p><a for=list>Append</a> <var>buffer</var> to <var>url</var>'s <a for=url>path</a>.
         </ol>
 
        <li><p>Set <var>buffer</var> to the empty string.
-
-       <li><p>If <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>" and <a>c</a> is the
-       <a>EOF code point</a>, U+003F (?), or U+0023 (#), then while <var>url</var>'s
-       <a for=url>path</a>'s <a for=list>size</a> is greater than 1 and <var>url</var>'s
-       <a for=url>path</a>[0] is the empty string, <a>validation error</a>, <a for=list>remove</a>
-       the first <a for=list>item</a> from <var>url</var>'s <a for=url>path</a>.
 
        <li><p>If <a>c</a> is U+003F (?), then set <var>url</var>'s <a for=url>query</a> to the empty
        string and <var>state</var> to <a>query state</a>.
@@ -3402,6 +3385,7 @@ Albert Wiersch,
 Alex Christensen,
 Alexandre Morgaut,
 Alexis Hunt,
+Alwin Blok,
 Andrew Sullivan,
 Arkadiusz Michalski,
 Behnam Esfahbod,


### PR DESCRIPTION
Changes to file URL path normalization as proposed in #405.  

Summary:

Applicable only to file URLs:
- Leading empty path segements are no longer removed. 
- If absent, the host is copied from the base URL,
- Otherwise the host is preserved with one exception:
- If the host is `localhost` then it is set to the empty string. 

Intends to close #405 and #302. 

- Tests: https://github.com/web-platform-tests/wpt/pull/25716. 
- Reference implementation: https://github.com/jsdom/whatwg-url/pull/170.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/544.html" title="Last updated on Sep 29, 2020, 9:54 AM UTC (3469a42)">Preview</a> | <a href="https://whatpr.org/url/544/83adf0c...3469a42.html" title="Last updated on Sep 29, 2020, 9:54 AM UTC (3469a42)">Diff</a>