### PR TITLE
Correct percent-encode example and add one

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -302,9 +302,12 @@ a <var>percentEncodeSet</var>, return the result of running
    <th>Input
    <th>Output
   <tr>
-   <td><a for=byte>Percent-encode</a> <var>input</var>
-   <td>0x7F
+   <td rowspan=2><a for=byte>Percent-encode</a> <var>input</var>
+   <td>0x23
    <td>"<code>%23</code>"
+  <tr>
+   <td>0x7F
+   <td>"<code>%7F</code>"
   <tr>
    <td><a for="byte sequence">Percent-decode</a> <var>input</var>
    <td>`<code>%25%s%1G</code>`
@@ -3493,6 +3496,7 @@ Tristan Seligmann,
 Valentin Gosu,
 Vyacheslav Matva,
 Wei Wang,
+Wolf Lammen,
 山岸和利 (Yamagishi Kazutoshi),
 Yongsheng Zhang,
 成瀬ゆい (Yui Naruse), and


### PR DESCRIPTION
Fixes #545.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/546.html" title="Last updated on Sep 29, 2020, 7:22 AM UTC (8c58e3c)">Preview</a> | <a href="https://whatpr.org/url/546/83adf0c...8c58e3c.html" title="Last updated on Sep 29, 2020, 7:22 AM UTC (8c58e3c)">Diff</a>