### PR TITLE
Fix file URL reparse issue

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2536,9 +2536,10 @@ then runs these steps, returning an <a>ASCII string</a>:
   <p>Otherwise:
 
   <ol>
-   <li><p>If <var>url</var>'s <a for=url>host</a> is null, <var>url</var>'s <a for=url>path</a>'s
-   <a for=list>size</a> is greater than 1, and <var>url</var>'s <a for=url>path</a>[0] is the empty
-   string, then append U+002F (/) followed by U+002E (.) to <var>output</var>.
+   <li><p>If <var>url</var>'s <a for=url>host</a> is null, <var>url</var> <a>is not special</a>,
+   <var>url</var>'s <a for=url>path</a>'s <a for=list>size</a> is greater than 1, and
+   <var>url</var>'s <a for=url>path</a>[0] is the empty string, then append U+002F (/) followed by
+   U+002E (.) to <var>output</var>.
 
    <li><p><a for=list>For each</a> <var>segment</var> of <var>url</var>'s <a for=url>path</a>:
    append U+002F (/) followed by <var>segment</var> to <var>output</var>.

--- a/url.bs
+++ b/url.bs
@@ -2536,7 +2536,7 @@ then runs these steps, returning an <a>ASCII string</a>:
   <p>Otherwise:
 
   <ol>
-   <li><p>If <var>url</var>'s <a for=url>host</a> is null, <var>url</var> <a>is not special</a>,
+   <li><p>If <var>url</var> <a>is not special</a>, <var>url</var>'s <a for=url>host</a> is null,
    <var>url</var>'s <a for=url>path</a>'s <a for=list>size</a> is greater than 1, and
    <var>url</var>'s <a for=url>path</a>[0] is the empty string, then append U+002F (/) followed by
    U+002E (.) to <var>output</var>.

--- a/url.bs
+++ b/url.bs
@@ -2536,10 +2536,9 @@ then runs these steps, returning an <a>ASCII string</a>:
   <p>Otherwise:
 
   <ol>
-   <li><p>If <var>url</var> <a>is not special</a>, <var>url</var>'s <a for=url>host</a> is null,
-   <var>url</var>'s <a for=url>path</a>'s <a for=list>size</a> is greater than 1, and
-   <var>url</var>'s <a for=url>path</a>[0] is the empty string, then append U+002F (/) followed by
-   U+002E (.) to <var>output</var>.
+   <li><p>If <var>url</var>'s <a for=url>host</a> is null, <var>url</var>'s <a for=url>path</a>'s
+   <a for=list>size</a> is greater than 1, and <var>url</var>'s <a for=url>path</a>[0] is the empty
+   string, then append U+002F (/) followed by U+002E (.) to <var>output</var>.
 
    <li><p><a for=list>For each</a> <var>segment</var> of <var>url</var>'s <a for=url>path</a>:
    append U+002F (/) followed by <var>segment</var> to <var>output</var>.

--- a/url.bs
+++ b/url.bs
@@ -1260,7 +1260,7 @@ It is initially the empty string.
    <td>✅
    <td>❌
    <td>✅
-   <td>✅
+   <td>❌
   <tr>
    <td>Others
    <td>❌
@@ -1762,7 +1762,7 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
          and <var>buffer</var> is "<code>file</code>", then return.
 
          <li><p>If <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>" and its
-         <a for=url>host</a> is an <a>empty host</a> or null, then return.
+         <a for=url>host</a> is an <a>empty host</a>, then return.
         </ol>
 
        <li><p>Set <var>url</var>'s <a for=url>scheme</a> to <var>buffer</var>.
@@ -2138,6 +2138,8 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
    <dd>
     <ol>
      <li><p>Set <var>url</var>'s <a for=url>scheme</a> to "<code>file</code>".
+
+     <li><p>Set <var>url</var>'s <a for=url>host</a> to the empty string.
 
      <li>
       <p>If <a>c</a> is U+002F (/) or U+005C (\), then:
@@ -2524,10 +2526,6 @@ then runs these steps, returning an <a>ASCII string</a>:
    <var>url</var>'s <a for=url>port</a>, <a lt="serialize an integer">serialized</a>, to
    <var>output</var>.
   </ol>
-
- <li><p>Otherwise, if <var>url</var>'s <a for=url>host</a> is null and
- <var>url</var>'s <a for=url>scheme</a> is "<code>file</code>", append
- "<code>//</code>" to <var>output</var>.
 
  <li><p>If <var>url</var>'s <a for=url>cannot-be-a-base-URL flag</a> is set, append <var>url</var>'s
  <a for=url>path</a>[0] to <var>output</var>.


### PR DESCRIPTION
Fixes issue by ensuring file URL's host is not null.

Changes:
- Set url's host to the empty string at the start of file state.
- Updates URL parser and serializer accordingly.

Fixes: https://github.com/whatwg/url/issues/549

<!--
Thank you for contributing to the URL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/25989
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: no bugs
   * Firefox: no bugs
   * Safari: no bugs

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/550.html" title="Last updated on Oct 7, 2020, 9:56 AM UTC (bcad0c4)">Preview</a> | <a href="https://whatpr.org/url/550/47efa00...bcad0c4.html" title="Last updated on Oct 7, 2020, 9:56 AM UTC (bcad0c4)">Diff</a>