### PR TITLE
Make it easier to talk about parts of the URL from outside the URL spec

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1216,18 +1216,18 @@ unified model would be, please file an issue.
 <p>A <dfn export id=concept-url lt="URL|URL record">URL</dfn> is a universal identifier. To
 disambiguate from a <a>valid URL string</a> it can also be referred to as a <a for=/>URL record</a>.
 
-<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-scheme>scheme</dfn> is an
+<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-scheme lt="scheme | url scheme">scheme</dfn> is an
 <a>ASCII string</a> that identifies the type of <a for=/>URL</a> and can be used to
 dispatch a <a for=/>URL</a> for further processing after <a lt="URL parser">parsing</a>.
 It is initially the empty string.
 
-<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-username>username</dfn> is an
+<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-username lt="username | url username">username</dfn> is an
 <a>ASCII string</a> identifying a username. It is initially the empty string.
 
-<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-password>password</dfn> is an
+<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-password lt="password | url password">password</dfn> is an
 <a>ASCII string</a> identifying a password. It is initially the empty string.
 
-<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-host>host</dfn> is null or a
+<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-host lt="host | url host">host</dfn> is null or a
 <a for=/>host</a>. It is initially null.
 
 <div class="note">
@@ -1272,20 +1272,20 @@ It is initially the empty string.
  </table>
 </div>
 
-<p>A  <a for=/>URL</a>'s <dfn export for=url id=concept-url-port>port</dfn> is either
+<p>A  <a for=/>URL</a>'s <dfn export for=url id=concept-url-port lt="port | url port">port</dfn> is either
 null or a 16-bit unsigned integer that identifies a networking port. It is initially null.
 
-<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-path>path</dfn> is a <a for=/>list</a> of
+<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-path lt="path | url path">path</dfn> is a <a for=/>list</a> of
 zero or more <a>ASCII strings</a>, usually identifying a location in hierarchical form. It is
 initially empty.
 
 <p class="note no-backref">A <a lt="is special">special</a> <a for=/>URL</a> always has a
 <a for=list lt="is empty">non-empty</a> <a for=url>path</a>.
 
-<p>A  <a for=/>URL</a>'s <dfn export for=url id=concept-url-query>query</dfn> is either
+<p>A  <a for=/>URL</a>'s <dfn export for=url id=concept-url-query lt="query | url query">query</dfn> is either
 null or an <a>ASCII string</a>. It is initially null.
 
-<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-fragment>fragment</dfn> is either null or
+<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-fragment lt="fragment | url fragment">fragment</dfn> is either null or
 an <a>ASCII string</a> that can be used for further processing on the resource the
 <a for=/>URL</a>'s other components identify. It is initially null.
 


### PR DESCRIPTION
This allows links like [=URL fragment=].