### PR TITLE
Fix handling of spaceAsPlus in percent-encode after encoding

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -247,7 +247,7 @@ optional boolean <var>spaceAsPlus</var> (default false), run these steps:
 
     <ol>
      <li><p>If <var>spaceAsPlus</var> is true and <var>byte</var> is 0x20 (SP), then append
-     U+002B (+) to <var>output</var>.
+     U+002B (+) to <var>output</var> and continue.
 
      <li><p>Let <var>isomorph</var> be a <a for=/>code point</a> whose <a for="code point">value</a>
      is <var>byte</var>'s <a for=byte>value</a>.

--- a/url.bs
+++ b/url.bs
@@ -247,7 +247,7 @@ optional boolean <var>spaceAsPlus</var> (default false), run these steps:
 
     <ol>
      <li><p>If <var>spaceAsPlus</var> is true and <var>byte</var> is 0x20 (SP), then append
-     U+002B (+) to <var>output</var> and continue.
+     U+002B (+) to <var>output</var> and <a for=iteration>continue</a>.
 
      <li><p>Let <var>isomorph</var> be a <a for=/>code point</a> whose <a for="code point">value</a>
      is <var>byte</var>'s <a for=byte>value</a>.


### PR DESCRIPTION
Closes #569.

<!--
Thank you for contributing to the URL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [X] At least two implementers are interested (and none opposed):
   * This is a spec bug introduced in #558; all browsers do the right thing here.
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * This is tested in [https://github.com/web-platform-tests/wpt/blob/master/url/url-searchparams.any.js], for example.
- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/570.html" title="Last updated on Jan 4, 2021, 10:47 AM UTC (d519278)">Preview</a> | <a href="https://whatpr.org/url/570/2ce4938...d519278.html" title="Last updated on Jan 4, 2021, 10:47 AM UTC (d519278)">Diff</a>