### PR TITLE
Editorial: algorithms can now have default argument values

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1689,8 +1689,8 @@ these steps:
  <li><p>Let <var>state</var> be <var>state override</var>
  if given, or <a>scheme start state</a> otherwise.
 
- <li><p>If <var>encoding</var> is not <a>UTF-8</a>, then set <var>encoding</var> to the result of
- <a>getting an output encoding</a> from <var>encoding</var>.
+ <li><p>Set <var>encoding</var> to the result of <a>getting an output encoding</a> from
+ <var>encoding</var>.
 
  <li><p>Let <var>buffer</var> be the empty string.
 
@@ -2572,11 +2572,11 @@ these steps:
 
 <ol>
  <li><p>Let <var>serializedA</var> be the result of <a lt="URL serializer">serializing</a>
- <var>A</var>, with <a for="URL serializer"><var>exclude fragment</var></a> set to
+ <var>A</var>, with <a for="URL serializer"><i>exclude fragment</i></a> set to
  <var>exclude fragments</var>.
 
  <li><p>Let <var>serializedB</var> be the result of <a lt="URL serializer">serializing</a>
- <var>B</var>, with <a for="URL serializer"><var>exclude fragment</var></a> set to
+ <var>B</var>, with <a for="URL serializer"><i>exclude fragment</i></a> set to
  <var>exclude fragments</var>.
 
  <li><p>Return true if <var>serializedA</var> is <var>serializedB</var>; otherwise false.
@@ -2786,8 +2786,8 @@ takes a list of name-value tuples <var>tuples</var>, with an optional <a for=/>e
 <var>encoding</var> (default <a>UTF-8</a>), and then runs these steps:
 
 <ol>
- <li><p>If <var>encoding</var> is not <a>UTF-8</a>, then set <var>encoding</var> to the result of
- <a>getting an output encoding</a> from <var>encoding</var>.
+ <li><p>Set <var>encoding</var> to the result of <a>getting an output encoding</a> from
+ <var>encoding</var>.
 
  <li><p>Let <var>output</var> be the empty string.
 
@@ -2971,8 +2971,8 @@ url.pathname // "/%F0%9F%8F%B3%EF%B8%8F%E2%80%8D%F0%9F%8C%88"</code></pre>
 
 <p>The <code><a attribute for=URL>protocol</a></code> setter steps are to
 <a lt="basic URL parser">basic URL parse</a> the given value, followed by U+003A (:), with
-<a>this</a>'s <a for=URL>URL</a> as <a for="basic URL parser"><var>url</var></a> and
-<a>scheme start state</a> as <a for="basic URL parser"><var>state override</var></a>.
+<a>this</a>'s <a for=URL>URL</a> as <a for="basic URL parser"><i>url</i></a> and
+<a>scheme start state</a> as <a for="basic URL parser"><i>state override</i></a>.
 
 <p>The <dfn attribute for=URL><code>username</code></dfn> getter steps are to return <a>this</a>'s
 <a for=URL>URL</a>'s <a for=url>username</a>.
@@ -3020,8 +3020,8 @@ url.pathname // "/%F0%9F%8F%B3%EF%B8%8F%E2%80%8D%F0%9F%8C%88"</code></pre>
  return.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> the given value with <a>this</a>'s
- <a for=URL>URL</a> as <a for="basic URL parser"><var>url</var></a> and <a>host state</a> as
- <a for="basic URL parser"><var>state override</var></a>.
+ <a for=URL>URL</a> as <a for="basic URL parser"><i>url</i></a> and <a>host state</a> as
+ <a for="basic URL parser"><i>state override</i></a>.
 </ol>
 
 <p class="note no-backref">If the given value for the <code><a attribute for=URL>host</a></code>
@@ -3046,8 +3046,8 @@ does return a <a>URL-port string</a> so one might have assumed the setter to alw
  return.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> the given value with <a>this</a>'s
- <a for=URL>URL</a> as <a for="basic URL parser"><var>url</var></a> and <a>hostname state</a> as
- <a for="basic URL parser"><var>state override</var></a>.
+ <a for=URL>URL</a> as <a for="basic URL parser"><i>url</i></a> and <a>hostname state</a> as
+ <a for="basic URL parser"><i>state override</i></a>.
 </ol>
 
 <p>The <dfn attribute for=URL><code>port</code></dfn> getter steps are:
@@ -3070,8 +3070,8 @@ does return a <a>URL-port string</a> so one might have assumed the setter to alw
  <a for=url>port</a> to null.</p></li>
 
  <li><p>Otherwise, <a lt="basic URL parser">basic URL parse</a> the given value with
- <a>this</a>'s <a for=URL>URL</a> as <a for="basic URL parser"><var>url</var></a> and
- <a>port state</a> as <a for="basic URL parser"><var>state override</var></a>.
+ <a>this</a>'s <a for=URL>URL</a> as <a for="basic URL parser"><i>url</i></a> and
+ <a>port state</a> as <a for="basic URL parser"><i>state override</i></a>.
 </ol>
 
 <p>The <dfn attribute for=URL><code>pathname</code></dfn> getter steps are:
@@ -3096,8 +3096,8 @@ does return a <a>URL-port string</a> so one might have assumed the setter to alw
  <li><p>Empty <a>this</a>'s <a for=URL>URL</a>'s <a for=url>path</a>.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> the given value with <a>this</a>'s
- <a for=URL>URL</a> as <a for="basic URL parser"><var>url</var></a> and <a>path start state</a> as
- <a for="basic URL parser"><var>state override</var></a>.
+ <a for=URL>URL</a> as <a for="basic URL parser"><i>url</i></a> and <a>path start state</a> as
+ <a for="basic URL parser"><i>state override</i></a>.
 </ol>
 
 <p>The <dfn attribute for=URL><code>search</code></dfn> getter steps are:
@@ -3122,8 +3122,8 @@ does return a <a>URL-port string</a> so one might have assumed the setter to alw
  <li><p>Set <var>url</var>'s <a for=url>query</a> to the empty string.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> <var>input</var> with <var>url</var> as
- <a for="basic URL parser"><var>url</var></a> and <a>query state</a> as
- <a for="basic URL parser"><var>state override</var></a>.
+ <a for="basic URL parser"><i>url</i></a> and <a>query state</a> as
+ <a for="basic URL parser"><i>state override</i></a>.
 
  <li><p>Set <a>this</a>'s <a for=URL>query object</a>'s <a for=URLSearchParams>list</a> to the
  result of <a lt="urlencoded string parser">parsing</a> <var>input</var>.
@@ -3152,8 +3152,8 @@ does return a <a>URL-port string</a> so one might have assumed the setter to alw
  <li><p>Set <a>this</a>'s <a for=URL>URL</a>'s <a for=url>fragment</a> to the empty string.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> <var>input</var> with <a>this</a>'s
- <a for=URL>URL</a> as <a for="basic URL parser"><var>url</var></a> and <a>fragment state</a> as
- <a for="basic URL parser"><var>state override</var></a>.
+ <a for=URL>URL</a> as <a for="basic URL parser"><i>url</i></a> and <a>fragment state</a> as
+ <a for="basic URL parser"><i>state override</i></a>.
 </ol>
 
 

--- a/url.bs
+++ b/url.bs
@@ -525,7 +525,7 @@ decisions made, i.e. whether to use the <a>same site</a> or <a>schemelessly same
 <h3 id=idna>IDNA</h3>
 
 <p>The <dfn id=concept-domain-to-ascii>domain to ASCII</dfn> algorithm, given a <a>string</a>
-<var>domain</var> and optionally a boolean <var>beStrict</var> (default false), runs these steps:
+<var>domain</var> and an optional boolean <var>beStrict</var> (default false), runs these steps:
 
 <ol>
  <li><p>Let <var>result</var> be the result of running <a abstract-op lt=ToASCII>Unicode ToASCII</a>
@@ -1623,8 +1623,9 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
 <h3 id=url-parsing>URL parsing</h3>
 
 <p>The <dfn export id=concept-url-parser lt="URL parser">URL parser</dfn> takes a string
-<var>input</var>, with an optional <a>base URL</a> <var>base</var> (default null) and an optional
-<a for=/>encoding</a> <var>encoding</var> (default <a>UTF-8</a>), and then runs these steps:
+<var>input</var>, with an optional null or <a>base URL</a> <var>base</var> (default null) and an
+optional <a for=/>encoding</a> <var>encoding</var> (default <a>UTF-8</a>), and then runs these
+steps:
 
 <p class="note no-backref">Non-web-browser implementations only need to implement the
 <a>basic URL parser</a>.
@@ -1652,14 +1653,16 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
 <hr>
 
 <p>The <dfn export id=concept-basic-url-parser lt="basic URL parser">basic URL parser</dfn> takes a
-string <var>input</var>, optionally with a <a>base URL</a> <var>base</var> (default null),
-optionally with an <a for=/>encoding</a> <var>encoding</var> (default <a>UTF-8</a>), optionally with
-a <a for=/>URL</a> <var>url</var> and a state override <var>state override</var>, and then runs
+string <var>input</var>, with an optional null or <a>base URL</a> <var>base</var> (default null), an
+optional <a for=/>encoding</a> <var>encoding</var> (default <a>UTF-8</a>), an optional
+<a for=/>URL</a> <dfn export for="basic URL parser"><var>url</var></dfn>, and an optional
+state override <dfn export for="basic URL parser"><var>state override</var></dfn>, and then runs
 these steps:
 
 <div class="note no-backref">
  <p>The <var>encoding</var> argument is a legacy concept only relevant for <cite>HTML</cite>. The
  <var>url</var> and <var>state override</var> arguments are only for use by various APIs. [[!HTML]]
+ <!-- HTMLHyperlinkElementUtils, Location, and URL -->
 
  <p>When the <var>url</var> and <var>state override</var> arguments are not passed, the
  <a>basic URL parser</a> returns either a new <a for=/>URL</a> or failure. If they are passed, the
@@ -2494,8 +2497,9 @@ these steps:
 <h3 id=url-serializing>URL serializing</h3>
 
 <p>The <dfn export id=concept-url-serializer lt="URL serializer">URL serializer</dfn> takes a
-<a for=/>URL</a> <var>url</var>, an optional <i title>exclude fragment flag</i>, and
-then runs these steps, returning an <a>ASCII string</a>:
+<a for=/>URL</a> <var>url</var>, with an optional boolean
+<dfn export for="URL serializer"><var>exclude fragment</var></dfn> (default false), and then runs
+these steps. They return an <a>ASCII string</a>.
 
 <ol>
  <li><p>Let <var>output</var> be <var>url</var>'s <a for=url>scheme</a> and U+003A (:) concatenated.
@@ -2551,9 +2555,9 @@ then runs these steps, returning an <a>ASCII string</a>:
  U+003F (?), followed by <var>url</var>'s <a for=url>query</a>, to
  <var>output</var>.
 
- <li><p>If the <i title>exclude fragment flag</i> is unset and <var>url</var>'s
- <a for=url>fragment</a> is non-null, append U+0023 (#), followed by
- <var>url</var>'s <a for=url>fragment</a>, to <var>output</var>.
+ <li><p>If <var>exclude fragment</var> is false and <var>url</var>'s <a for=url>fragment</a> is
+ non-null, then append U+0023 (#), followed by <var>url</var>'s <a for=url>fragment</a>, to
+ <var>output</var>.
 
  <li><p>Return <var>output</var>.
 </ol>
@@ -2562,20 +2566,20 @@ then runs these steps, returning an <a>ASCII string</a>:
 <h3 id=url-equivalence>URL equivalence</h3>
 
 <p>To determine whether a <a for=/>URL</a> <var>A</var>
-<dfn export for=url id=concept-url-equals lt=equal>equals</dfn> <var>B</var>, optionally with an
-<i>exclude fragments flag</i>, run these steps:
+<dfn export for=url id=concept-url-equals lt=equal>equals</dfn> <var>B</var>, with an optional
+boolean with an <dfn export for="url/equals"><var>exclude fragments</var></dfn> (default false), run
+these steps:
 
 <ol>
  <li><p>Let <var>serializedA</var> be the result of <a lt="URL serializer">serializing</a>
- <var>A</var>, with the <i>exclude fragment flag</i> set if the
- <i>exclude fragments flag</i> is set.
+ <var>A</var>, with <a for="URL serializer"><var>exclude fragment</var></a> set to
+ <var>exclude fragments</var>.
 
  <li><p>Let <var>serializedB</var> be the result of <a lt="URL serializer">serializing</a>
- <var>B</var>, with the <i>exclude fragment flag</i> set if the
- <i>exclude fragments flag</i> is set.
+ <var>B</var>, with <a for="URL serializer"><var>exclude fragment</var></a> set to
+ <var>exclude fragments</var>.
 
- <li><p>Return true if <var>serializedA</var> is <var>serializedB</var>, and false
- otherwise.
+ <li><p>Return true if <var>serializedA</var> is <var>serializedB</var>; otherwise false.
 </ol>
 
 
@@ -2778,7 +2782,7 @@ takes a byte sequence <var>input</var>, and then runs these steps:
 
 <p>The
 <dfn export id=concept-urlencoded-serializer lt="urlencoded serializer"><code>application/x-www-form-urlencoded</code> serializer</dfn>
-takes a list of name-value tuples <var>tuples</var>, optionally with an <a for=/>encoding</a>
+takes a list of name-value tuples <var>tuples</var>, with an optional <a for=/>encoding</a>
 <var>encoding</var> (default <a>UTF-8</a>), and then runs these steps:
 
 <ol>
@@ -2967,8 +2971,8 @@ url.pathname // "/%F0%9F%8F%B3%EF%B8%8F%E2%80%8D%F0%9F%8C%88"</code></pre>
 
 <p>The <code><a attribute for=URL>protocol</a></code> setter steps are to
 <a lt="basic URL parser">basic URL parse</a> the given value, followed by U+003A (:), with
-<a>this</a>'s <a for=URL>URL</a> as <var>url</var> and <a>scheme start state</a> as
-<var>state override</var>.
+<a>this</a>'s <a for=URL>URL</a> as <a for="basic URL parser"><var>url</var></a> and
+<a>scheme start state</a> as <a for="basic URL parser"><var>state override</var></a>.
 
 <p>The <dfn attribute for=URL><code>username</code></dfn> getter steps are to return <a>this</a>'s
 <a for=URL>URL</a>'s <a for=url>username</a>.
@@ -3016,7 +3020,8 @@ url.pathname // "/%F0%9F%8F%B3%EF%B8%8F%E2%80%8D%F0%9F%8C%88"</code></pre>
  return.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> the given value with <a>this</a>'s
- <a for=URL>URL</a> as <var>url</var> and <a>host state</a> as <var>state override</var>.
+ <a for=URL>URL</a> as <a for="basic URL parser"><var>url</var></a> and <a>host state</a> as
+ <a for="basic URL parser"><var>state override</var></a>.
 </ol>
 
 <p class="note no-backref">If the given value for the <code><a attribute for=URL>host</a></code>
@@ -3041,7 +3046,8 @@ does return a <a>URL-port string</a> so one might have assumed the setter to alw
  return.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> the given value with <a>this</a>'s
- <a for=URL>URL</a> as <var>url</var> and <a>hostname state</a> as <var>state override</var>.
+ <a for=URL>URL</a> as <a for="basic URL parser"><var>url</var></a> and <a>hostname state</a> as
+ <a for="basic URL parser"><var>state override</var></a>.
 </ol>
 
 <p>The <dfn attribute for=URL><code>port</code></dfn> getter steps are:
@@ -3064,8 +3070,8 @@ does return a <a>URL-port string</a> so one might have assumed the setter to alw
  <a for=url>port</a> to null.</p></li>
 
  <li><p>Otherwise, <a lt="basic URL parser">basic URL parse</a> the given value with
- <a>this</a>'s <a for=URL>URL</a> as <var>url</var> and <a>port state</a> as
- <var>state override</var>.
+ <a>this</a>'s <a for=URL>URL</a> as <a for="basic URL parser"><var>url</var></a> and
+ <a>port state</a> as <a for="basic URL parser"><var>state override</var></a>.
 </ol>
 
 <p>The <dfn attribute for=URL><code>pathname</code></dfn> getter steps are:
@@ -3090,7 +3096,8 @@ does return a <a>URL-port string</a> so one might have assumed the setter to alw
  <li><p>Empty <a>this</a>'s <a for=URL>URL</a>'s <a for=url>path</a>.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> the given value with <a>this</a>'s
- <a for=URL>URL</a> as <var>url</var> and <a>path start state</a> as <var>state override</var>.
+ <a for=URL>URL</a> as <a for="basic URL parser"><var>url</var></a> and <a>path start state</a> as
+ <a for="basic URL parser"><var>state override</var></a>.
 </ol>
 
 <p>The <dfn attribute for=URL><code>search</code></dfn> getter steps are:
@@ -3115,7 +3122,8 @@ does return a <a>URL-port string</a> so one might have assumed the setter to alw
  <li><p>Set <var>url</var>'s <a for=url>query</a> to the empty string.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> <var>input</var> with <var>url</var> as
- <var>url</var> and <a>query state</a> as <var>state override</var>.
+ <a for="basic URL parser"><var>url</var></a> and <a>query state</a> as
+ <a for="basic URL parser"><var>state override</var></a>.
 
  <li><p>Set <a>this</a>'s <a for=URL>query object</a>'s <a for=URLSearchParams>list</a> to the
  result of <a lt="urlencoded string parser">parsing</a> <var>input</var>.
@@ -3144,7 +3152,8 @@ does return a <a>URL-port string</a> so one might have assumed the setter to alw
  <li><p>Set <a>this</a>'s <a for=URL>URL</a>'s <a for=url>fragment</a> to the empty string.
 
  <li><p><a lt="basic URL parser">Basic URL parse</a> <var>input</var> with <a>this</a>'s
- <a for=URL>URL</a> as <var>url</var> and <a>fragment state</a> as <var>state override</var>.
+ <a for=URL>URL</a> as <a for="basic URL parser"><var>url</var></a> and <a>fragment state</a> as
+ <a for="basic URL parser"><var>state override</var></a>.
 </ol>
 
 

--- a/url.bs
+++ b/url.bs
@@ -525,11 +525,9 @@ decisions made, i.e. whether to use the <a>same site</a> or <a>schemelessly same
 <h3 id=idna>IDNA</h3>
 
 <p>The <dfn id=concept-domain-to-ascii>domain to ASCII</dfn> algorithm, given a <a>string</a>
-<var>domain</var> and optionally a boolean <var>beStrict</var>, runs these steps:
+<var>domain</var> and optionally a boolean <var>beStrict</var> (default false), runs these steps:
 
 <ol>
- <li><p>If <var>beStrict</var> is not given, set it to false.
-
  <li><p>Let <var>result</var> be the result of running <a abstract-op lt=ToASCII>Unicode ToASCII</a>
  with <i>domain_name</i> set to <var>domain</var>, <i>UseSTD3ASCIIRules</i> set to
  <var>beStrict</var>, <i>CheckHyphens</i> set to false, <i>CheckBidi</i> set to true,
@@ -614,11 +612,10 @@ requires context to be distinguished.
 <h3 id=host-parsing>Host parsing</h3>
 
 <p>The <dfn export id=concept-host-parser lt="host parser|host parsing">host parser</dfn> takes a
-string <var>input</var> with an optional boolean <var>isNotSpecial</var>, and then runs these steps:
+string <var>input</var> with an optional boolean <var>isNotSpecial</var> (default false), and then
+runs these steps:
 
 <ol>
- <li><p>If <var>isNotSpecial</var> is not given, then set <var>isNotSpecial</var> to false.
-
  <li>
   <p>If <var>input</var> starts with U+005B ([), then:
 
@@ -1626,8 +1623,8 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
 <h3 id=url-parsing>URL parsing</h3>
 
 <p>The <dfn export id=concept-url-parser lt="URL parser">URL parser</dfn> takes a string
-<var>input</var>, with an optional <a>base URL</a> <var>base</var> and an optional
-<a for=/>encoding</a> <var>encoding override</var>, and then runs these steps:
+<var>input</var>, with an optional <a>base URL</a> <var>base</var> (default null) and an optional
+<a for=/>encoding</a> <var>encoding</var> (default <a>UTF-8</a>), and then runs these steps:
 
 <p class="note no-backref">Non-web-browser implementations only need to implement the
 <a>basic URL parser</a>.
@@ -1637,9 +1634,8 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
 <a href="#url-rendering">URL rendering requirements</a> as they pertain trust decisions.
 
 <ol>
- <li><p>Let <var>url</var> be the result of running the
- <a>basic URL parser</a> on <var>input</var>
- with <var>base</var>, and <var>encoding override</var> as provided.
+ <li><p>Let <var>url</var> be the result of running the <a>basic URL parser</a> on <var>input</var>
+ with <var>base</var> and <var>encoding</var>.
 
  <li><p>If <var>url</var> is failure, return failure.
 
@@ -1656,14 +1652,14 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
 <hr>
 
 <p>The <dfn export id=concept-basic-url-parser lt="basic URL parser">basic URL parser</dfn> takes a
-string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, optionally with an
-<a for=/>encoding</a> <var>encoding override</var>, optionally with a <a for=/>URL</a>
-<var>url</var> and a state override <var>state override</var>, and then runs these steps:
+string <var>input</var>, optionally with a <a>base URL</a> <var>base</var> (default null),
+optionally with an <a for=/>encoding</a> <var>encoding</var> (default <a>UTF-8</a>), optionally with
+a <a for=/>URL</a> <var>url</var> and a state override <var>state override</var>, and then runs
+these steps:
 
 <div class="note no-backref">
- <p>The <var>encoding override</var> argument is a legacy concept only relevant for
- HTML. The <var>url</var> and <var>state override</var> arguments are only for use by various APIs.
- [[!HTML]]
+ <p>The <var>encoding</var> argument is a legacy concept only relevant for <cite>HTML</cite>. The
+ <var>url</var> and <var>state override</var> arguments are only for use by various APIs. [[!HTML]]
 
  <p>When the <var>url</var> and <var>state override</var> arguments are not passed, the
  <a>basic URL parser</a> returns either a new <a for=/>URL</a> or failure. If they are passed, the
@@ -1690,12 +1686,8 @@ string <var>input</var>, optionally with a <a>base URL</a> <var>base</var>, opti
  <li><p>Let <var>state</var> be <var>state override</var>
  if given, or <a>scheme start state</a> otherwise.
 
- <li><p>If <var>base</var> is not given, set it to null.
-
- <li><p>Let <var>encoding</var> be <a>UTF-8</a>.
-
- <li><p>If <var>encoding override</var> is given, set <var>encoding</var> to the result of
- <a lt="get an output encoding">getting an output encoding</a> from <var>encoding override</var>.
+ <li><p>If <var>encoding</var> is not <a>UTF-8</a>, then set <var>encoding</var> to the result of
+ <a>getting an output encoding</a> from <var>encoding</var>.
 
  <li><p>Let <var>buffer</var> be the empty string.
 
@@ -2787,13 +2779,11 @@ takes a byte sequence <var>input</var>, and then runs these steps:
 <p>The
 <dfn export id=concept-urlencoded-serializer lt="urlencoded serializer"><code>application/x-www-form-urlencoded</code> serializer</dfn>
 takes a list of name-value tuples <var>tuples</var>, optionally with an <a for=/>encoding</a>
-<var>encoding override</var>, and then runs these steps:
+<var>encoding</var> (default <a>UTF-8</a>), and then runs these steps:
 
 <ol>
- <li><p>Let <var>encoding</var> be <a>UTF-8</a>.
-
- <li><p>If <var>encoding override</var> is given, then set <var>encoding</var> to the result of
- <a lt="get an output encoding">getting an output encoding</a> from <var>encoding override</var>.
+ <li><p>If <var>encoding</var> is not <a>UTF-8</a>, then set <var>encoding</var> to the result of
+ <a>getting an output encoding</a> from <var>encoding</var>.
 
  <li><p>Let <var>output</var> be the empty string.
 


### PR DESCRIPTION
Thanks Infra!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 1, 2021, 5:49 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Furl%2Fc55bf428c077e37cd954f32af2f2bc552deea74b%2Furl.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20575)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/url%23575.)._
</details>
