### PR TITLE
Editorial: Fix notation for empty path

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1309,7 +1309,7 @@ need to succeed.
    <td>"<code>https</code>"
    <td>"<code>example.com</code>"
    <td>null
-   <td>« the empty string »
+   <td>« »
    <td>null
    <td>null
    <td>false


### PR DESCRIPTION
> A URL’s path is a list of zero or more ASCII strings, usually identifying a location in hierarchical form. It is initially empty. 

However, [the URI example table](https://url.spec.whatwg.org/#example-url-components) says `« the empty string » ` not `«  »` (for the empty list).

https://github.com/whatwg/url/blob/b40eb97221ad039df7f3cf3814c024f6de75c69d/url.bs#L1312


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/579.html" title="Last updated on Feb 11, 2021, 2:59 AM UTC (1fd12d2)">Preview</a> | <a href="https://whatpr.org/url/579/b40eb97...1fd12d2.html" title="Last updated on Feb 11, 2021, 2:59 AM UTC (1fd12d2)">Diff</a>