### PR TITLE
Prevent the pathname setter from erasing the path of path-only URLs, …

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2298,6 +2298,10 @@ these steps:
 
        <li><p>If <a>c</a> is not U+002F (/), then decrease <var>pointer</var> by 1.
       </ol>
+
+     <li><p>Otherwise, if <var>state override</var> is given and <var>url</var>'s
+      <a for=url>host</a> is null, <a for=list>append</a> the empty string to <var>url</var>'s
+      <a for=url>path</a>
     </ol>
 
    <dt><dfn>path state</dfn>
@@ -3439,6 +3443,7 @@ Jeffrey Yasskin,
 Joe Duarte,
 Joshua Bell,
 Jxck,
+Karl Wagner,
 田村健人 (Kent TAMURA),
 Kevin Grandon,
 Kornel Lesiński,

--- a/url.bs
+++ b/url.bs
@@ -2300,8 +2300,8 @@ these steps:
       </ol>
 
      <li><p>Otherwise, if <var>state override</var> is given and <var>url</var>'s
-      <a for=url>host</a> is null, <a for=list>append</a> the empty string to <var>url</var>'s
-      <a for=url>path</a>
+     <a for=url>host</a> is null, <a for=list>append</a> the empty string to <var>url</var>'s
+     <a for=url>path</a>.
     </ol>
 
    <dt><dfn>path state</dfn>


### PR DESCRIPTION
…as that would make them cannot-be-a-base URLs.

Fixes #581 

JSDom patch: https://github.com/jsdom/whatwg-url/pull/178

- [ ] At least two implementers are interested (and none opposed):
   * Me 😅
   * …
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/27720
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/582.html" title="Last updated on Jun 17, 2021, 8:12 AM UTC (405c917)">Preview</a> | <a href="https://whatpr.org/url/582/557567c...405c917.html" title="Last updated on Jun 17, 2021, 8:12 AM UTC (405c917)">Diff</a>