### PR TITLE
[Editorial] Guarantee that strings encoded with the component encode-set are valid opaque host strings.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -205,7 +205,7 @@ U+0024 ($) to U+0026 (&amp;), inclusive, U+002B (+), and U+002C (,).
 <p class=note>This is used by <cite>HTML</cite> for
 {{NavigatorContentUtils/registerProtocolHandler()}}, and could also be used by other standards to
 percent-encode data that can then be embedded in a <a for=/>URL</a>'s <a for=url>path</a>,
-<a for=url>query</a>, or <a for=url>fragment</a>. Using it with
+<a for=url>query</a>, or <a for=url>fragment</a>; or in an <a for=/>opaque host</a>. Using it with
 <a for=string>UTF-8 percent-encode</a> gives identical results to JavaScript's
 <a method><code>encodeURIComponent()</code> [sic]</a>. [[HTML]] [[ECMA-262]]
 
@@ -3439,6 +3439,7 @@ Jeffrey Yasskin,
 Joe Duarte,
 Joshua Bell,
 Jxck,
+Karl Wagner,
 田村健人 (Kent TAMURA),
 Kevin Grandon,
 Kornel Lesiński,


### PR DESCRIPTION
Users require guidance about how to encode data as an opaque host string - for instance, it is common to want to encode a filesystem path as a hostname to create an `http+unix:` URL.

Moreover, the `host`/`hostname` setter is unique in that it will fail if the new value contains forbidden host code units, unlike other setters which automatically percent-encode any invalid characters, so it is important that users correctly encode the new value in order for the operation to succeed.

I would like to advise users to encode their hostnames with the component encode-set, and it would be nice if there was an explicit mention in the standard to back this advice up - as there is for the path, query and fragment.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/584.html" title="Last updated on Mar 3, 2021, 10:44 AM UTC (73b10cf)">Preview</a> | <a href="https://whatpr.org/url/584/557567c...73b10cf.html" title="Last updated on Mar 3, 2021, 10:44 AM UTC (73b10cf)">Diff</a>