### PR TITLE
Editorial: remove support for files in the urlencoded serialization

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2800,15 +2800,11 @@ takes a list of name-value tuples <var>tuples</var>, with an optional <a for=/>e
    <var>tuple</var>'s name, the
    <a><code>application/x-www-form-urlencoded</code> percent-encode set</a>, and true.
 
-   <li><p>Let <var>value</var> be <var>tuple</var>'s value.
-
-   <li><p>If <var>value</var> is a file, then set <var>value</var> to <var>value</var>'s filename.
-
-   <li><p>Set <var>value</var> to the result of running
-   <a for=string>percent-encode after encoding</a> with <var>encoding</var>, <var>value</var>, the
+   <li><p>Let <var>value</var> be the result of running <a for=string>percent-encode after
+   encoding</a> with <var>encoding</var>, <var>value</var>, the
    <a><code>application/x-www-form-urlencoded</code> percent-encode set</a>, and true.
 
-   <li><p>If <var>tuple</var> is not <var>tuples</var>[0], then append U+0026 (&amp;) to
+   <li><p>If <var>output</var> is not the empty string, then append U+0026 (&amp;) to
    <var>output</var>.
 
    <li>Append <var>name</var>, followed by U+003D (=), followed by <var>value</var>, to
@@ -2817,8 +2813,6 @@ takes a list of name-value tuples <var>tuples</var>, with an optional <a for=/>e
 
  <li>Return <var>output</var>.
 </ol>
-
-<p class=note><cite>HTML</cite> invokes this algorithm with values that are files. [[HTML]]
 
 
 <h3 id=urlencoded-hooks>Hooks</h3>

--- a/url.bs
+++ b/url.bs
@@ -2800,9 +2800,9 @@ takes a list of name-value tuples <var>tuples</var>, with an optional <a for=/>e
    <var>tuple</var>'s name, the
    <a><code>application/x-www-form-urlencoded</code> percent-encode set</a>, and true.
 
-   <li><p>Let <var>value</var> be the result of running <a for=string>percent-encode after
-   encoding</a> with <var>encoding</var>, <var>value</var>, the
-   <a><code>application/x-www-form-urlencoded</code> percent-encode set</a>, and true.
+   <li><p>Let <var>value</var> be the result of running
+   <a for=string>percent-encode after encoding</a> with <var>encoding</var>, <var>tuple</var>'s
+   value, the <a><code>application/x-www-form-urlencoded</code> percent-encode set</a>, and true.
 
    <li><p>If <var>output</var> is not the empty string, then append U+0026 (&amp;) to
    <var>output</var>.


### PR DESCRIPTION
After whatwg/html#6287, no callers are left which invoke the `application/x-www-form-urlencoded` serializer with file values.

Do not merge before whatwg/html#6287.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/585.html" title="Last updated on Feb 27, 2021, 12:40 PM UTC (ef7153f)">Preview</a> | <a href="https://whatpr.org/url/585/557567c...ef7153f.html" title="Last updated on Feb 27, 2021, 12:40 PM UTC (ef7153f)">Diff</a>