### PR TITLE
Fix typo

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -445,7 +445,7 @@ U+0040 (@), U+005B ([), U+005C (\), U+005D (]), or U+005E (^).
 </ol>
 
 <p>A <a for=/>host</a>'s <dfn for=host export>registrable domain</dfn> is a <a>domain</a> formed by
-the most specific public suffix, along with the domain label immediately preceeding it, if any. To
+the most specific public suffix, along with the domain label immediately preceding it, if any. To
 obtain <var>host</var>'s <a for=host>registrable domain</a>, run these steps:
 
 <ol>


### PR DESCRIPTION
I replaced `preceeding` by `preceding`. That’s it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/586.html" title="Last updated on Mar 2, 2021, 10:08 PM UTC (056f17c)">Preview</a> | <a href="https://whatpr.org/url/586/557567c...056f17c.html" title="Last updated on Mar 2, 2021, 10:08 PM UTC (056f17c)">Diff</a>