### PR TITLE
Forbid | in URL hosts

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -426,7 +426,7 @@ processing.
 
 <p>A <dfn export>forbidden host code point</dfn> is U+0000 NULL, U+0009 TAB, U+000A LF, U+000D CR,
 U+0020 SPACE, U+0023 (#), U+0025 (%), U+002F (/), U+003A (:), U+003C (&lt;), U+003E (>), U+003F (?),
-U+0040 (@), U+005B ([), U+005C (\), U+005D (]), or U+005E (^).
+U+0040 (@), U+005B ([), U+005C (\), U+005D (]), U+005E (^), or U+007C (|).
 
 <p>A <a for=/>host</a>'s <dfn for=host export>public suffix</dfn> is the portion of a
 <a for=/>host</a> which is included on the <cite>Public Suffix List</cite>. To obtain


### PR DESCRIPTION
This fixes issue #559.

<!--
Thank you for contributing to the URL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/589.html" title="Last updated on Mar 17, 2021, 4:53 PM UTC (899e68a)">Preview</a> | <a href="https://whatpr.org/url/589/6c66d6c...899e68a.html" title="Last updated on Mar 17, 2021, 4:53 PM UTC (899e68a)">Diff</a>