### PR TITLE
Make hostname state return early if a port is given

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2024,6 +2024,9 @@ these steps:
        <li><p>If <var>buffer</var> is the empty string, <a>validation error</a>, return failure.
        <!-- No URLs with port, but without host. -->
 
+       <li><p>If <var>state override</var> is given and <var>state override</var> is
+       <a>hostname state</a>, then return.
+
        <li><p>Let <var>host</var> be the result of <a>host parsing</a> <var>buffer</var> with
        <var>url</var> <a>is not special</a>.
 
@@ -2032,9 +2035,6 @@ these steps:
        <li><p>Set <var>url</var>'s <a for=url>host</a> to
        <var>host</var>, <var>buffer</var> to the empty string,
        and <var>state</var> to <a>port state</a>.
-
-       <li><p>If <var>state override</var> is given and <var>state override</var> is
-       <a>hostname state</a>, then return.
       </ol>
 
      <li>


### PR DESCRIPTION
Fixes #601.

<!--
Thank you for contributing to the URL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Firefox (already implemented)
   * Safari (already implemented)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/29021
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/1018721
   * Node.js: https://github.com/nodejs/node/issues/38710
   * whatwg-url: https://github.com/jsdom/whatwg-url/pull/183

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/604.html" title="Last updated on May 19, 2021, 4:17 PM UTC (974b094)">Preview</a> | <a href="https://whatpr.org/url/604/8c24e54...974b094.html" title="Last updated on May 19, 2021, 4:17 PM UTC (974b094)">Diff</a>