### PR TITLE
Emit validation errors more consistently

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2055,7 +2055,7 @@ these steps:
 
        <li><p>Otherwise, if <var>state override</var> is given, <var>buffer</var> is the empty
        string, and either <var>url</var> <a>includes credentials</a> or <var>url</var>'s
-       <a for=url>port</a> is non-null, <a>validation error</a>, return.
+       <a for=url>port</a> is non-null, return.
 
        <li><p>Let <var>host</var> be the result of <a>host parsing</a> <var>buffer</var> with
        <var>url</var> <a>is not special</a>.


### PR DESCRIPTION
In particular, only use them when the URL parser is invoked without an override state.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/605.html" title="Last updated on May 19, 2021, 6:51 PM UTC (3e1652b)">Preview</a> | <a href="https://whatpr.org/url/605/ec96993...3e1652b.html" title="Last updated on May 19, 2021, 6:51 PM UTC (3e1652b)">Diff</a>