### PR TITLE
Reject non-IPv4 hostnames that end in numbers.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -655,16 +655,39 @@ runs these steps:
  <li><p>If <var>asciiDomain</var> contains a <a>forbidden host code point</a>,
  <a>validation error</a>, return failure.
 
- <li><p>Let <var>ipv4Host</var> be the result of <a lt="IPv4 parser">IPv4 parsing</a>
- <var>asciiDomain</var>.
-
- <li><p>If <var>ipv4Host</var> is an <a>IPv4 address</a> or failure, return
- <var>ipv4Host</var>.
+ <li><p>If <var>asciiDomain</var> <a lt="ends in a number"> ends in a numer, return
+ the result of <a lt="IPv4 parser">IPv4 parsing</a> <var>asciiDomain</var>.
 
  <li><p>Return <var>asciiDomain</var>.
 </ol>
 
 <hr>
+
+<p>The <dfn id=ends-in-a-number>ends in a number checker</dfn> takes a string <var>input</var> and
+then runs these steps:
+
+<ol>
+ <li><p>Let <var>parts</var> be the result of <a>strictly splitting</a> <var>input</var> on
+ U+002E (.).
+
+ <li>
+  <p>If the last <a for=list>item</a> in <var>parts</var> is the empty string, then:
+
+  <ol>
+   <li><p>If <var>parts</var>'s <a for=list>size</a> is 1, return false.
+
+   <li>Otherwise, <a for=list>remove</a> the last <a for=list>item</a> from <var>parts</var>.
+  </ol>
+
+ <li><p>Let <var>last</var> be the last <a for=list>item</a> from <var>parts</var>.
+
+ <li>If parsing <var>last</var> as an <a lt="IPv4 number parser">IPv4 number</a> does not
+ return failure, return true.
+
+ <li><p>If <var>last</var> is non-empty and contains only <a>ASCII digits</a>, return true.
+
+ <li><p>Return false.
+</ol>
 
 <p>The <dfn id=concept-ipv4-parser>IPv4 parser</dfn> takes a string <var>input</var> and then runs
 these steps:
@@ -692,7 +715,8 @@ these steps:
         but if it somehow is this conditional makes sure we can keep going. -->
   </ol>
 
- <li><p>If <var>parts</var>'s <a for=list>size</a> is greater than 4, then return <var>input</var>.
+ <li><p>If <var>parts</var>'s <a for=list>size</a> is greater than 4, then <a>validation error</a>,
+ return failure.
 
  <li><p>Let <var>numbers</var> be an empty <a for=/>list</a>.
 
@@ -700,16 +724,10 @@ these steps:
   <p><a for=list>For each</a> <var>part</var> of <var>parts</var>:
 
   <ol>
-   <li>
-    <p>If <var>part</var> is the empty string, then return <var>input</var>.
-
-    <p class="example no-backref" id=example-c2afe535><code>0..0x300</code> is a
-    <a>domain</a>, not an <a>IPv4 address</a>.
-
    <li><p>Let <var>result</var> be the result of <a lt="IPv4 number parser">parsing</a>
    <var>part</var>.
 
-   <li><p>If <var>result</var> is failure, then return <var>input</var>.
+   <li><p>If <var>result</var> is failure, then <a>validation error</a>, return failure.
 
    <li><p>If <var>result</var>[1] is true, then set <var>validationError</var> to true.
 
@@ -754,7 +772,9 @@ these steps:
 <p>The <dfn>IPv4 number parser</dfn> takes a string <var>input</var> and then runs these steps:
 
 <ol>
- <li><p>Let <var>validationError</var> be false.
+ <li><p>If <var>input</var> is the empty string, then return failure.
+
+<li><p>Let <var>validationError</var> be false.
 
  <li><p>Let <var>R</var> be 10.
 

--- a/url.bs
+++ b/url.bs
@@ -686,6 +686,10 @@ then runs these steps:
 
  <li><p>If <var>last</var> is non-empty and contains only <a>ASCII digits</a>, return true.
 
+ <p class="note no-backref">This can happen if <var>last</var> starts with "0" so the
+ <a lt="IPv4 number parser">IPv4 number parser</a> tries to parse it as octal, but it is not
+ a valid octal number, as is the case with, for example, "09".
+
  <li><p>Return false.
 </ol>
 

--- a/url.bs
+++ b/url.bs
@@ -655,7 +655,7 @@ runs these steps:
  <li><p>If <var>asciiDomain</var> contains a <a>forbidden host code point</a>,
  <a>validation error</a>, return failure.
 
- <li><p>If <var>asciiDomain</var> <a lt="ends in a number"> ends in a numer, return
+ <li><p>If <var>asciiDomain</var> <a lt="ends in a number checker"> ends in a numer, return
  the result of <a lt="IPv4 parser">IPv4 parsing</a> <var>asciiDomain</var>.
 
  <li><p>Return <var>asciiDomain</var>.

--- a/url.bs
+++ b/url.bs
@@ -679,10 +679,10 @@ steps:
    <li><p><a for=list>Remove</a> the last <a for=list>item</a> from <var>parts</var>.
   </ol>
 
- <li><p>Let <var>last</var> be the last <a for=list>item</a> from <var>parts</var>.
+ <li><p>Let <var>last</var> be the last <a for=list>item</a> in <var>parts</var>.
 
  <li><p>If parsing <var>last</var> as an <a lt="IPv4 number parser">IPv4 number</a> does not
- return failure, return true.
+ return failure, then return true.
 
  <li>
   <p>If <var>last</var> is non-empty and contains only <a>ASCII digits</a>, then return true.

--- a/url.bs
+++ b/url.bs
@@ -655,7 +655,7 @@ runs these steps:
  <li><p>If <var>asciiDomain</var> contains a <a>forbidden host code point</a>,
  <a>validation error</a>, return failure.
 
- <li><p>If <var>asciiDomain</var> <a lt="ends in a number checker">ends in a number</a>, return
+ <li><p>If <var>asciiDomain</var> <a lt="ends in a number checker">ends in a number</a>, then return
  the result of <a lt="IPv4 parser">IPv4 parsing</a> <var>asciiDomain</var>.
 
  <li><p>Return <var>asciiDomain</var>.
@@ -663,8 +663,8 @@ runs these steps:
 
 <hr>
 
-<p>The <dfn id=ends-in-a-number>ends in a number checker</dfn> takes a string <var>input</var> and
-then runs these steps:
+<p>The <dfn>ends in a number checker</dfn> takes a string <var>input</var> and then runs these
+steps:
 
 <ol>
  <li><p>Let <var>parts</var> be the result of <a>strictly splitting</a> <var>input</var> on
@@ -674,9 +674,9 @@ then runs these steps:
   <p>If the last <a for=list>item</a> in <var>parts</var> is the empty string, then:
 
   <ol>
-   <li><p>If <var>parts</var>'s <a for=list>size</a> is 1, return false.
+   <li><p>If <var>parts</var>'s <a for=list>size</a> is 1, then return false.
 
-   <li><p><a for=list>remove</a> the last <a for=list>item</a> from <var>parts</var>.
+   <li><p><a for=list>Remove</a> the last <a for=list>item</a> from <var>parts</var>.
   </ol>
 
  <li><p>Let <var>last</var> be the last <a for=list>item</a> from <var>parts</var>.
@@ -684,11 +684,12 @@ then runs these steps:
  <li><p>If parsing <var>last</var> as an <a lt="IPv4 number parser">IPv4 number</a> does not
  return failure, return true.
 
- <li><p>If <var>last</var> is non-empty and contains only <a>ASCII digits</a>, return true.
+ <li>
+  <p>If <var>last</var> is non-empty and contains only <a>ASCII digits</a>, then return true.
 
- <p class="note no-backref">This can happen if <var>last</var> starts with "0" so the
- <a lt="IPv4 number parser">IPv4 number parser</a> tries to parse it as octal, but it is not
- a valid octal number, as is the case with, for example, "09".
+  <p class=note>This can happen if <var>last</var> starts with "<code>0</code>" so the
+  <a lt="IPv4 number parser">IPv4 number parser</a> tries to parse it as octal, but it is not a
+  valid octal number, as is the case with, for example, "<code>09</code>".
 
  <li><p>Return false.
 </ol>
@@ -719,7 +720,7 @@ these steps:
         but if it somehow is this conditional makes sure we can keep going. -->
   </ol>
 
- <li><p>If <var>parts</var>'s <a for=list>size</a> is greater than 4, then <a>validation error</a>,
+ <li><p>If <var>parts</var>'s <a for=list>size</a> is greater than 4, <a>validation error</a>,
  return failure.
 
  <li><p>Let <var>numbers</var> be an empty <a for=/>list</a>.
@@ -731,7 +732,7 @@ these steps:
    <li><p>Let <var>result</var> be the result of <a lt="IPv4 number parser">parsing</a>
    <var>part</var>.
 
-   <li><p>If <var>result</var> is failure, then <a>validation error</a>, return failure.
+   <li><p>If <var>result</var> is failure, <a>validation error</a>, return failure.
 
    <li><p>If <var>result</var>[1] is true, then set <var>validationError</var> to true.
 

--- a/url.bs
+++ b/url.bs
@@ -655,7 +655,7 @@ runs these steps:
  <li><p>If <var>asciiDomain</var> contains a <a>forbidden host code point</a>,
  <a>validation error</a>, return failure.
 
- <li><p>If <var>asciiDomain</var> <a lt="ends in a number checker"> ends in a numer, return
+ <li><p>If <var>asciiDomain</var> <a lt="ends in a number checker">ends in a number</a>, return
  the result of <a lt="IPv4 parser">IPv4 parsing</a> <var>asciiDomain</var>.
 
  <li><p>Return <var>asciiDomain</var>.

--- a/url.bs
+++ b/url.bs
@@ -676,7 +676,7 @@ then runs these steps:
   <ol>
    <li><p>If <var>parts</var>'s <a for=list>size</a> is 1, return false.
 
-   <li>Otherwise, <a for=list>remove</a> the last <a for=list>item</a> from <var>parts</var>.
+   <li><p><a for=list>remove</a> the last <a for=list>item</a> from <var>parts</var>.
   </ol>
 
  <li><p>Let <var>last</var> be the last <a for=list>item</a> from <var>parts</var>.

--- a/url.bs
+++ b/url.bs
@@ -681,7 +681,7 @@ then runs these steps:
 
  <li><p>Let <var>last</var> be the last <a for=list>item</a> from <var>parts</var>.
 
- <li>If parsing <var>last</var> as an <a lt="IPv4 number parser">IPv4 number</a> does not
+ <li><p>If parsing <var>last</var> as an <a lt="IPv4 number parser">IPv4 number</a> does not
  return failure, return true.
 
  <li><p>If <var>last</var> is non-empty and contains only <a>ASCII digits</a>, return true.

--- a/url.bs
+++ b/url.bs
@@ -778,7 +778,7 @@ these steps:
 <ol>
  <li><p>If <var>input</var> is the empty string, then return failure.
 
-<li><p>Let <var>validationError</var> be false.
+ <li><p>Let <var>validationError</var> be false.
 
  <li><p>Let <var>R</var> be 10.
 


### PR DESCRIPTION
This is aimed at addressing issue #560.  If the last component of a URL's hostname is numeric, it's parsed as an IPv4 hostname, and if that fails, the URL's host is rejected.  e.g., "foo.0", "bar.0.09", "a.1.2.0x.", "1.2.3.4.5" were all previously considered valid non-IPv4 hostnames, but are now all rejected.  See #560 for more discussion on why allowing these are potentially concerning.

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * FireFox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/29666
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/1237032
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1723456
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=228826

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/619.html" title="Last updated on Aug 5, 2021, 2:47 PM UTC (c09bcfa)">Preview</a> | <a href="https://whatpr.org/url/619/0672f2e...c09bcfa.html" title="Last updated on Aug 5, 2021, 2:47 PM UTC (c09bcfa)">Diff</a>