### PR TITLE
Meta: export basic URL parser states

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1738,7 +1738,7 @@ these steps:
   <var>pointer</var> by 1 and continue with the state machine.
 
   <dl class=switch>
-   <dt><dfn>scheme start state</dfn>
+   <dt><dfn export for="basic URL parser" id=scheme-start-state>scheme start state</dfn>
    <dd>
     <ol>
      <li><p>If <a>c</a> is an <a>ASCII alpha</a>,
@@ -1755,7 +1755,7 @@ these steps:
       {{Location/protocol}} setter.
     </ol>
 
-   <dt><dfn>scheme state</dfn>
+   <dt><dfn export for="basic URL parser" id=scheme-state>scheme state</dfn>
    <dd>
     <ol>
      <li><p>If <a>c</a> is an <a>ASCII alphanumeric</a>, U+002B (+), U+002D (-), or U+002E (.),
@@ -1838,7 +1838,7 @@ these steps:
       is an intentional difference for defining that setter.
     </ol>
 
-   <dt><dfn>no scheme state</dfn>
+   <dt><dfn export for="basic URL parser" id=no-scheme-state>no scheme state</dfn>
    <dd>
     <ol>
      <li><p>If <var>base</var> is null, or <var>base</var>'s <a for=url>cannot-be-a-base-URL</a> is
@@ -1862,7 +1862,7 @@ these steps:
      by 1.
     </ol>
 
-   <dt><dfn>special relative or authority state</dfn>
+   <dt><dfn export for="basic URL parser" id=special-relative-or-authority-state>special relative or authority state</dfn>
    <dd>
     <ol>
      <li><p>If <a>c</a> is U+002F (/) and <a>remaining</a> starts with U+002F (/), then set
@@ -1873,7 +1873,7 @@ these steps:
      decrease <var>pointer</var> by 1.
     </ol>
 
-   <dt><dfn>path or authority state</dfn>
+   <dt><dfn export for="basic URL parser" id=path-or-authority-state>path or authority state</dfn>
    <dd>
     <ol>
      <li><p>If <a>c</a> is U+002F (/), then set <var>state</var> to <a>authority state</a>.
@@ -1882,7 +1882,7 @@ these steps:
      by 1.
     </ol>
 
-   <dt><dfn>relative state</dfn>
+   <dt><dfn export for="basic URL parser" id=relative-state>relative state</dfn>
    <dd>
     <ol>
      <li><p>Assert: <var>base</var>'s <a for=url>scheme</a> is not "<code>file</code>".
@@ -1930,7 +1930,7 @@ these steps:
       </ol>
     </ol>
 
-   <dt><dfn>relative slash state</dfn>
+   <dt><dfn export for="basic URL parser" id=relative-slash-state>relative slash state</dfn>
    <dd>
     <ol>
      <li>
@@ -1957,7 +1957,7 @@ these steps:
      <var>state</var> to <a>path state</a>, and then, decrease <var>pointer</var> by 1.
     </ol>
 
-   <dt><dfn>special authority slashes state</dfn>
+   <dt><dfn export for="basic URL parser" id=special-authority-slashes-state>special authority slashes state</dfn>
    <dd>
     <ol>
      <li><p>If <a>c</a> is U+002F (/) and <a>remaining</a> starts with U+002F (/), then set
@@ -1968,7 +1968,7 @@ these steps:
      <a>special authority ignore slashes state</a> and decrease <var>pointer</var> by 1.
     </ol>
 
-   <dt><dfn>special authority ignore slashes state</dfn>
+   <dt><dfn export for="basic URL parser" id=special-authority-ignore-slashes-state>special authority ignore slashes state</dfn>
    <dd>
     <ol>
      <li><p>If <a>c</a> is neither U+002F (/) nor U+005C (\), then set <var>state</var> to
@@ -1977,7 +1977,7 @@ these steps:
      <li><p>Otherwise, <a>validation error</a>.
     </ol>
 
-   <dt><dfn>authority state</dfn>
+   <dt><dfn export for="basic URL parser" id=authority-state>authority state</dfn>
    <dd>
     <ol>
      <li>
@@ -2037,8 +2037,8 @@ these steps:
      <li><p>Otherwise, append <a>c</a> to <var>buffer</var>.
     </ol>
 
-   <dt><dfn>host state</dfn>
-   <dt><dfn>hostname state</dfn>
+   <dt><dfn export for="basic URL parser" id=host-state>host state</dfn>
+   <dt><dfn export for="basic URL parser" id=hostname-state>hostname state</dfn>
    <dd>
     <ol>
      <li><p>If <var>state override</var> is given and <var>url</var>'s <a for=url>scheme</a> is
@@ -2109,7 +2109,7 @@ these steps:
       </ol>
     </ol>
 
-   <dt><dfn>port state</dfn>
+   <dt><dfn export for="basic URL parser" id=port-state>port state</dfn>
    <dd>
     <ol>
      <li><p>If <a>c</a> is an <a>ASCII digit</a>, append <a>c</a> to <var>buffer</var>.
@@ -2152,7 +2152,7 @@ these steps:
      <li><p>Otherwise, <a>validation error</a>, return failure.
     </ol>
 
-   <dt><dfn>file state</dfn>
+   <dt><dfn export for="basic URL parser" id=file-state>file state</dfn>
    <dd>
     <ol>
      <li><p>Set <var>url</var>'s <a for=url>scheme</a> to "<code>file</code>".
@@ -2215,7 +2215,7 @@ these steps:
      by 1.
     </ol>
 
-   <dt><dfn>file slash state</dfn>
+   <dt><dfn export for="basic URL parser" id=file-slash-state>file slash state</dfn>
    <dd>
     <ol>
      <li>
@@ -2253,7 +2253,7 @@ these steps:
       </ol>
     </ol>
 
-   <dt><dfn>file host state</dfn>
+   <dt><dfn export for="basic URL parser" id=file-host-state>file host state</dfn>
    <dd>
     <ol>
      <li>
@@ -2304,7 +2304,7 @@ these steps:
      <li><p>Otherwise, append <a>c</a> to <var>buffer</var>.
     </ol>
 
-   <dt><dfn>path start state</dfn>
+   <dt><dfn export for="basic URL parser" id=path-start-state>path start state</dfn>
    <dd>
     <ol>
      <li>
@@ -2341,7 +2341,7 @@ these steps:
      <a for=url>path</a>.
     </ol>
 
-   <dt><dfn>path state</dfn>
+   <dt><dfn export for="basic URL parser" id=path-state>path state</dfn>
    <dd>
     <ol>
      <li>
@@ -2443,7 +2443,7 @@ these steps:
       </ol>
     </ol>
 
-   <dt><dfn>query state</dfn>
+   <dt><dfn export for="basic URL parser" id=query-state>query state</dfn>
    <dd>
     <ol>
      <li>
@@ -2499,7 +2499,7 @@ these steps:
       </ol>
     </ol>
 
-   <dt><dfn>fragment state</dfn>
+   <dt><dfn export for="basic URL parser" id=fragment-state>fragment state</dfn>
    <dd>
     <ol>
      <li>


### PR DESCRIPTION
This helps https://github.com/WICG/urlpattern/issues/141. #655 will export the remaining state.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/659.html" title="Last updated on Oct 19, 2021, 9:37 AM UTC (d2be649)">Preview</a> | <a href="https://whatpr.org/url/659/4edcc9f...d2be649.html" title="Last updated on Oct 19, 2021, 9:37 AM UTC (d2be649)">Diff</a>