### PR TITLE
Cleanup language around special scheme and default port

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1380,13 +1380,14 @@ need to succeed.
 
 <h3 id=url-miscellaneous>URL miscellaneous</h3>
 
-<p>A <dfn export>special scheme</dfn> is a <a for=url>scheme</a> listed in the first column of
-the following table. A <dfn>default port</dfn> is a <a>special scheme</a>'s corresponding
-<a for=url>port</a> and is listed in the second column on the same row.
+<p>A <dfn export>special scheme</dfn> is an <a>ASCII string</a> that is listed in the first column
+of the following table. The <dfn export>default port</dfn> for a <a>special scheme</a> is listed in
+the second column on the same row. The <a>default port</a> for any other <a>ASCII string</a> is
+null.
 
 <table>
- <tr><th><a for=url>scheme</a>
-     <th><a for=url>port</a>
+ <tr><th><a>Special scheme</a>
+     <th><a>Default port</a>
  <tr><td>"<code>ftp</code>"<td>21
  <tr><td>"<code>file</code>"<td>null
  <tr><td>"<code>http</code>"<td>80
@@ -2138,8 +2139,7 @@ these steps:
          <a>validation error</a>, return failure.
 
          <li><p>Set <var>url</var>'s <a for=url>port</a> to null, if <var>port</var> is
-         <var>url</var>'s <a for=url>scheme</a>'s <a>default port</a>, and to
-         <var>port</var> otherwise.
+         <var>url</var>'s <a for=url>scheme</a>'s <a>default port</a>; otherwise to <var>port</var>.
 
          <li><p>Set <var>buffer</var> to the empty string.
         </ol>


### PR DESCRIPTION
Also export default port.

Helps with https://github.com/WICG/urlpattern/issues/142.

Closes #510.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/660.html" title="Last updated on Oct 19, 2021, 10:06 AM UTC (e3a8c2e)">Preview</a> | <a href="https://whatpr.org/url/660/4edcc9f...e3a8c2e.html" title="Last updated on Oct 19, 2021, 10:06 AM UTC (e3a8c2e)">Diff</a>