### PR TITLE
[Editorial] Remove a redundant condition in "cannot have a username/password/port"

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1448,7 +1448,8 @@ not a <a>special scheme</a>.
 <a for=/>string</a>.
 
 <p>A <a for=/>URL</a> <dfn export>cannot have a username/password/port</dfn> if its
-<a for=url>host</a> is null or the empty string, or its <a for=url>scheme</a> is "<code>file</code>".
+<a for=url>host</a> is null or the empty string, or its <a for=url>scheme</a> is
+"<code>file</code>".
 
 <p>A <a for=/>URL</a> can be designated as <dfn id=concept-base-url>base URL</dfn>.
 


### PR DESCRIPTION
If a URL has an opaque path, its host must already be null.

This makes the condition clearer and more direct - the reason you can't set a username/password/port on these URLs is because they lack an appropriate host. The fact that some such URLs may _also_ have opaque paths is a coincidence.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/667.html" title="Last updated on Oct 25, 2021, 3:44 PM UTC (b87aee6)">Preview</a> | <a href="https://whatpr.org/url/667/9d2d00c...b87aee6.html" title="Last updated on Oct 25, 2021, 3:44 PM UTC (b87aee6)">Diff</a>