### PR TITLE
[Editorial] Correct the note about the IDNA fast-path for ASCII domains

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -583,8 +583,8 @@ decisions made, i.e. whether to use the <a>same site</a> or <a>schemelessly same
 
   <p class=note>If <var>beStrict</var> is false, <var>domain</var> is an <a>ASCII string</a>, and
   <a>strictly splitting</a> <var>domain</var> on U+002E (.) does not produce any
-  <a for=list>item</a> that <a for=string>starts with</a> "<code>xn--</code>", this step is
-  equivalent to <a>ASCII lowercasing</a> <var>domain</var>.
+  <a for=list>item</a> that <a for=string>starts with</a> an <a>ASCII case-insensitive</a> match for
+  "<code>xn--</code>", this step is equivalent to <a>ASCII lowercasing</a> <var>domain</var>.
 
  <li><p>If <var>result</var> is a failure value, <a>validation error</a>, return failure.
 


### PR DESCRIPTION
The full IDNA algorithm lowercases before checking the `"xn--"` prefix, so any implementors fast-pathing ASCII domains should make sure that they check for it case-insensitively.

Added tests:
   * https://github.com/web-platform-tests/wpt/pull/32177


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/678.html" title="Last updated on Jan 14, 2022, 12:48 PM UTC (4f43025)">Preview</a> | <a href="https://whatpr.org/url/678/f787850...4f43025.html" title="Last updated on Jan 14, 2022, 12:48 PM UTC (4f43025)">Diff</a>