### PR TITLE
Review Draft Publication: February 2022

### DIFF
--- a/review-drafts/2022-02.bs
+++ b/review-drafts/2022-02.bs
@@ -1,5 +1,6 @@
 <pre class=metadata>
 Group: WHATWG
+Date: 2022-02-21
 H1: URL
 Shortname: url
 Text Macro: TWITTER urlstandard


### PR DESCRIPTION
The [February 2022 Review Draft](https://url.spec.whatwg.org/review-drafts/2022-02/) for this Workstream will be published shortly after merging this pull request.

Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/687.html" title="Last updated on Feb 21, 2022, 10:36 AM UTC (6003433)">Preview</a> | <a href="https://whatpr.org/url/687/c023c21...6003433.html" title="Last updated on Feb 21, 2022, 10:36 AM UTC (6003433)">Diff</a>