### PR TITLE
Meta: fix "same site" reference

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -595,7 +595,8 @@ for security decisions. The notion of "<a for=host>public suffix</a>" and
 "<a for=host>registrable domain</a>" cannot be relied-upon to provide a hard security boundary, as
 the public suffix list will diverge from client to client. Specifications which ignore this advice
 are encouraged to carefully consider whether URLs' schemes ought to be incorporated into any
-decisions made, i.e. whether to use the <a>same site</a> or <a>schemelessly same site</a> concepts.
+decisions made, i.e. whether to use the <a for=/>same site</a> or <a>schemelessly same site</a>
+concepts.
 
 
 <h3 id=idna>IDNA</h3>


### PR DESCRIPTION
Recently HTML introduced a for="site" version, so we need to be more specific.

Blocks #700.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/701.html" title="Last updated on Aug 15, 2022, 4:27 AM UTC (fbdfcb3)">Preview</a> | <a href="https://whatpr.org/url/701/4ef812c...fbdfcb3.html" title="Last updated on Aug 15, 2022, 4:27 AM UTC (fbdfcb3)">Diff</a>