### PR TITLE
Ensure the API roundtrips for opaque paths

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2998,6 +2998,20 @@ interface URL {
  object.
 </ul>
 
+<p>To <dfn>potentially strip trailing spaces from an opaque path</dfn> given a {{URL}} object
+<var>url</var>:
+
+<ol>
+ <li><p>If <var>url</var>'s <a for=URL>URL</a> does not have an <a for=url>opaque path</a>, then
+ return.
+
+ <li><p>If <var>url</var>'s <a for=URL>URL</a>'s <a for=url>fragment</a> is non-null, then return.
+
+ <li><p>If <var>url</var>'s <a for=URL>URL</a>'s <a for=url>query</a> is non-null, then return.
+
+ <li><p>Remove all trailing U+0020 from <var>url</var>'s <a for=URL>URL</a>'s <a for=url>path</a>.
+</ol>
+
 <hr>
 
 <p id=constructors>The
@@ -3233,8 +3247,19 @@ one might have assumed the setter to always "reset" both.
 <ol>
  <li><p>Let <var>url</var> be <a>this</a>'s <a for=URL>URL</a>.
 
- <li><p>If the given value is the empty string, set <var>url</var>'s <a for=url>query</a> to null,
- empty <a>this</a>'s <a for=URL>query object</a>'s <a for=URLSearchParams>list</a>, and then return.
+ <li>
+  <p>If the given value is the empty string:
+
+  <ol>
+   <li><p>Set <var>url</var>'s <a for=url>query</a> to null.
+
+   <li><p><a for=list>Empty</a> <a>this</a>'s <a for=URL>query object</a>'s
+   <a for=URLSearchParams>list</a>.
+
+   <li><p><a>Potentially strip trailing spaces from an opaque path</a> with <a>this</a>.
+
+   <li><p>Return.
+  </ol>
 
  <li><p>Let <var>input</var> be the given value with a single leading U+003F (?) removed, if any.
 
@@ -3263,8 +3288,16 @@ one might have assumed the setter to always "reset" both.
 <p>The <code><a attribute for=URL>hash</a></code> setter steps are:
 
 <ol>
- <li><p>If the given value is the empty string, then set <a>this</a>'s <a for=URL>URL</a>'s
- <a for=url>fragment</a> to null and return.
+ <li>
+  <p>If the given value is the empty string:
+
+  <ol>
+   <li><p>Set <a>this</a>'s <a for=URL>URL</a>'s <a for=url>fragment</a> to null.
+
+   <li><p><a>Potentially strip trailing spaces from an opaque path</a> with <a>this</a>.
+
+   <li><p>Return.
+  </ol>
 
  <li><p>Let <var>input</var> be the given value with a single leading U+0023 (#) removed, if any.
 
@@ -3386,6 +3419,10 @@ object <var>query</var>, run these steps:
 
  <li><p>Set <var>query</var>'s <a for=URLSearchParams>URL object</a>'s <a for=URL>URL</a>'s
  <a for=url>query</a> to <var>serializedQuery</var>.
+
+ <li><p>If <var>serializedQuery</var> is null, then
+ <a>potentially strip trailing spaces from an opaque path</a> with <var>query</var>'s
+ <a for=URLSearchParams>URL object</a>.
 </ol>
 
 <p>The

--- a/url.bs
+++ b/url.bs
@@ -3009,7 +3009,8 @@ interface URL {
 
  <li><p>If <var>url</var>'s <a for=URL>URL</a>'s <a for=url>query</a> is non-null, then return.
 
- <li><p>Remove all trailing U+0020 from <var>url</var>'s <a for=URL>URL</a>'s <a for=url>path</a>.
+ <li><p>Remove all trailing U+0020 SPACE <a for=/>code points</a> from <var>url</var>'s
+ <a for=URL>URL</a>'s <a for=url>path</a>.
 </ol>
 
 <hr>
@@ -3273,6 +3274,11 @@ one might have assumed the setter to always "reset" both.
  result of <a lt="urlencoded string parser">parsing</a> <var>input</var>.
 </ol>
 
+<p class=note>The {{URL/search}} setter has the potential to remove trailing U+0020 SPACE
+<a for=/>code points</a> from <a>this</a>'s <a for=URL>URL</a>'s <a for=url>path</a>. It does this
+so that running the <a>URL parser</a> on the output of running the <a>URL serializer</a> on
+<a>this</a>'s <a for=URL>URL</a> does not yield a <a for=/>URL</a> that is not <a for=url>equal</a>.
+
 <p>The <dfn attribute for=URL><code>searchParams</code></dfn> getter steps are to return
 <a>this</a>'s <a for=URL>query object</a>.
 
@@ -3307,6 +3313,9 @@ one might have assumed the setter to always "reset" both.
  <a for=URL>URL</a> as <a for="basic URL parser"><i>url</i></a> and <a>fragment state</a> as
  <a for="basic URL parser"><i>state override</i></a>.
 </ol>
+
+<p class=note>The {{URL/hash}} setter has the potential to change <a>this</a>'s <a for=URL>URL</a>'s
+<a for=url>path</a> in a manner equivalent to the {{URL/search}} setter.
 
 
 <h3 id=interface-urlsearchparams>URLSearchParams class</h3>
@@ -3373,6 +3382,10 @@ console.log(url.searchParams.get('b')); // "~"</code></pre>
  <li><dfn export for=URLSearchParams id=concept-urlsearchparams-url-object>URL object</dfn>: null or
  a {{URL}} object, initially null.
 </ul>
+
+<p class=note>A {{URLSearchParams}} object with a non-null <a for=URLSearchParams>URL object</a> has
+the potential to change that object's <a for=url>path</a> in a manner equivalent to the {{URL}}
+object's {{URL/search}} and {{URL/hash}} setters.
 
 <p>To <dfn for=URLSearchParams oldids=concept-urlsearchparams-new>initialize</dfn> a
 {{URLSearchParams}} object <var>query</var> with <var>init</var>, run these steps:


### PR DESCRIPTION
As opaque paths can end in U+0020, those trailing U+0020 code points need to be removed from the path when both query and fragment become null.

Tests: ...

Fixes #651.

<!--
Thank you for contributing to the URL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * WebKit
   * Gecko
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/37556
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * Node.js: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/728.html" title="Last updated on Dec 16, 2022, 3:50 PM UTC (fc3bee2)">Preview</a> | <a href="https://whatpr.org/url/728/50f0b09...fc3bee2.html" title="Last updated on Dec 16, 2022, 3:50 PM UTC (fc3bee2)">Diff</a>