### PR TITLE
Add a size getter to URLSearchParams

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -3360,6 +3360,8 @@ so that running the <a>URL parser</a> on the output of running the <a>URL serial
 interface URLSearchParams {
   constructor(optional (sequence&lt;sequence&lt;USVString>> or record&lt;USVString, USVString> or USVString) init = "");
 
+  readonly attribute unsigned long size;
+
   undefined append(USVString name, USVString value);
   undefined delete(USVString name);
   USVString? get(USVString name);
@@ -3483,6 +3485,9 @@ constructor steps are:</p>
 
  <li><p><a for=URLSearchParams>Initialize</a> <a>this</a> with <var>init</var>.
 </ol>
+
+<p>The <dfn attribute for=URLSearchParams><code>size</code></dfn> getter steps are to return
+<a>this</a>'s <a for=URLSearchParams>list</a>'s <a for=list>size</a>.
 
 <p>The <dfn method for=URLSearchParams><code>append(<var>name</var>, <var>value</var>)</code></dfn>
 method steps are:


### PR DESCRIPTION
Tests: https://github.com/web-platform-tests/wpt/pull/38655.

Fixes #163.

<!--
Thank you for contributing to the URL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/38655
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1418374
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1818269
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=252749
   * Deno: https://github.com/denoland/deno/issues/17882
   * Node.js: https://github.com/nodejs/node/pull/46308
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/24760

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/734.html" title="Last updated on Feb 22, 2023, 4:42 PM UTC (c02d79d)">Preview</a> | <a href="https://whatpr.org/url/734/fdaa0e5...c02d79d.html" title="Last updated on Feb 22, 2023, 4:42 PM UTC (c02d79d)">Diff</a>