### PR TITLE
Add Ada to implementations section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ A complete JavaScript implementation of the standard can be found at
 [jsdom/whatwg-url](https://github.com/jsdom/whatwg-url). This implementation is kept synchronized
 with the standard and tests.
 
+A complete C++ implementation of the standard can be found at
+[ada-url/ada](https://github.com/ada-url/ada). This implementation is kept synchronized
+with the standard and tests, and is currently used in [Node.js](https://github.com/nodejs/node).
+
 The [Live URL Viewer](https://jsdom.github.io/whatwg-url/) lets you manually test-parse any URL,
 comparing your browser's URL parser to that of
 [jsdom/whatwg-url](https://github.com/jsdom/whatwg-url).


### PR DESCRIPTION
This pull request adds `Ada`, a spec-compliant and fast URL parser to the implementations section of the readme. Ada is currently adopted by Node.js, and actively developed and maintained by me and Daniel Lemire (@lemire). It would be in the public interest to share a fast and compliant implementation of the URL parser.