### PR TITLE
Fix reference to resolve a blob URL

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1820,7 +1820,7 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
  "<code>blob</code>", return <var>url</var>.
 
  <li><p>Set <var>url</var>'s <a for=url>blob URL entry</a> to the result of
- <a for="blob URL" lt="resolve">resolving the blob URL</a> <var>url</var>, if that did not return
+ <a lt="resolve a blob URL">resolving the blob URL</a> <var>url</var>, if that did not return
  failure, and null otherwise.
 
  <li><p>Return <var>url</var>.


### PR DESCRIPTION
This was updated in https://github.com/w3c/FileAPI/pull/191


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/751.html" title="Last updated on Feb 8, 2023, 2:37 PM UTC (0d719e9)">Preview</a> | <a href="https://whatpr.org/url/751/2f7b688...0d719e9.html" title="Last updated on Feb 8, 2023, 2:37 PM UTC (0d719e9)">Diff</a>