### PR TITLE
Clarify return value of the IPv4 number parser

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -887,7 +887,7 @@ return value of the <a for=/>host parser</a> is an <a for=/>IPv4 address</a>.
 
 <div algorithm>
 <p>The <dfn>IPv4 number parser</dfn> takes an <a>ASCII string</a> <var>input</var> and then runs
-these steps:
+these steps. They return failure or a <a for=/>tuple</a> of a number and a boolean.
 
 <ol>
  <li><p>If <var>input</var> is the empty string, then return failure.


### PR DESCRIPTION
Editorial. This PR clarifies the return value of the IPv4 number parser.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/754.html" title="Last updated on Feb 13, 2023, 4:23 AM UTC (72e1ebf)">Preview</a> | <a href="https://whatpr.org/url/754/8653878...72e1ebf.html" title="Last updated on Feb 13, 2023, 4:23 AM UTC (72e1ebf)">Diff</a>