### PR TITLE
Return null origin of "blob:" URL containing inner non-"http(s):" URL

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -3081,6 +3081,9 @@ is the <a for=/>origin</a> returned by running these steps, switching on <var>ur
 
    <li><p>If <var>pathURL</var> is failure, then return a new <a>opaque origin</a>.
 
+   <li><p>If <var>pathURL</var>'s <a for=url>scheme</a> is not "<code>http</code>" and not
+   "<code>https</code>", then return a new <a>opaque origin</a>.
+
    <li><p>Return <var>pathURL</var>'s <a for=url>origin</a>.
    <!-- Did you mean: recursion -->
   </ol>


### PR DESCRIPTION
Fixes: #770.

<!--
Thank you for contributing to the URL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/40133
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: [Bug 1834703](https://bugzilla.mozilla.org/show_bug.cgi?id=1834703)
   * WebKit: …
   * Deno: …
   * Node.js: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/771.html" title="Last updated on May 24, 2023, 12:58 PM UTC (2782e9f)">Preview</a> | <a href="https://whatpr.org/url/771/bfb9157...2782e9f.html" title="Last updated on May 24, 2023, 12:58 PM UTC (2782e9f)">Diff</a>