### PR TITLE
Add file as allowed scheme for blob origin

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -3081,8 +3081,8 @@ is the <a for=/>origin</a> returned by running these steps, switching on <var>ur
 
    <li><p>If <var>pathURL</var> is failure, then return a new <a>opaque origin</a>.
 
-   <li><p>If <var>pathURL</var>'s <a for=url>scheme</a> is not "<code>http</code>" and not
-   "<code>https</code>", then return a new <a>opaque origin</a>.
+   <li><p>If <var>pathURL</var>'s <a for=url>scheme</a> is not "<code>http</code>", "<code>https</code>",
+   and "<code>file</code>" then return a new <a>opaque origin</a>.
 
    <li><p>Return <var>pathURL</var>'s <a for=url>origin</a>.
    <!-- Did you mean: recursion -->


### PR DESCRIPTION
This is a minor tweak to #771 to also include file as an allowed scheme for blob URL origins. Not sure if WPT changes are needed?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/775.html" title="Last updated on May 30, 2023, 6:21 PM UTC (1701175)">Preview</a> | <a href="https://whatpr.org/url/775/eee49fd...1701175.html" title="Last updated on May 30, 2023, 6:21 PM UTC (1701175)">Diff</a>