### PR TITLE
Editorial: correct URL path serializer markup

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -3025,7 +3025,7 @@ these steps. They return an <a>ASCII string</a>.
 <p>The <dfn export lt="URL path serializer|URL path serializing">URL path serializer</dfn> takes a
 <a for=/>URL</a> <var>url</var> and then runs these steps. They return an <a>ASCII string</a>.
 
-<ul>
+<ol>
  <li><p>If <var>url</var> has an <a for=url>opaque path</a>, then return <var>url</var>'s
  <a for=url>path</a>.
 
@@ -3035,7 +3035,7 @@ these steps. They return an <a>ASCII string</a>.
  U+002F (/) followed by <var>segment</var> to <var>output</var>.
 
  <li><p>Return <var>output</var>.
-</ul>
+</ol>
 
 
 <h3 id=url-equivalence>URL equivalence</h3>
@@ -4031,6 +4031,7 @@ Joe Duarte,
 Joshua Bell,
 Jxck,
 Karl Wagner,
+Kemal Zebari,
 田村健人 (Kent TAMURA),
 Kevin Grandon,
 Kornel Lesiński,


### PR DESCRIPTION
Fixes #786.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/787.html" title="Last updated on Sep 16, 2023, 3:05 PM UTC (ce9e37f)">Preview</a> | <a href="https://whatpr.org/url/787/d2ca75f...ce9e37f.html" title="Last updated on Sep 16, 2023, 3:05 PM UTC (ce9e37f)">Diff</a>