### PR TITLE
Fix validation error when a URL has credentials but no host

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2448,7 +2448,7 @@ and then runs these steps:
 
       <ol>
        <li><p>If <var>atSignSeen</var> is true and <var>buffer</var> is the empty string,
-       <a>invalid-credentials</a> <a>validation error</a>, return failure.
+       <a>host-missing</a> <a>validation error</a>, return failure.
        <!-- No URLs with userinfo, but without host. For special URLs it would also not be
             idempotent:
             https://@/example.org/ -> https:///example.org/ -> https://example.org/ -->

--- a/url.bs
+++ b/url.bs
@@ -309,9 +309,9 @@ const url = new URL("💩", "mailto:user@example.org");</code></pre>
     <p>The input <a>includes credentials</a>.
     <div class=example id=example-invalid-credentials>
      <p>"<code>https://user@example.org</code>"
-     <p>"<code>https://user:pass@</code>"
+     <p>"<code>ssh://user@example.org</code>"
     </div>
-   <td class=yes>Yes<br>(only if there is no host)
+   <td class=no>·
   <tr>
    <td><dfn>host-missing</dfn>
    <td>
@@ -319,6 +319,7 @@ const url = new URL("💩", "mailto:user@example.org");</code></pre>
     <div class=example id=example-host-missing>
      <p>"<code>https://#fragment</code>"
      <p>"<code>https://:443</code>"
+     <p>"<code>https://user:pass@</code>"
     </div>
    <td class=yes>Yes
   <tr>


### PR DESCRIPTION
Since this branch requires that `atSignSeen` is true, we must have already emitted an `invalid-credentials` validation error and this emission must be a duplicate.

What this check is actually doing is confirming that the host is not empty before it begins parsing it, so `host-missing` is a more appropriate error to emit.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * Node.js: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/793.html" title="Last updated on Sep 26, 2023, 8:32 AM UTC (6e3c878)">Preview</a> | <a href="https://whatpr.org/url/793/45a483a...6e3c878.html" title="Last updated on Sep 26, 2023, 8:32 AM UTC (6e3c878)">Diff</a>