### PR TITLE
[editorial] Rephrase encoding note to make the implications clearer.

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2038,8 +2038,8 @@ and <a>code points</a> in the range U+00A0 to U+10FFFD, inclusive, excluding <a>
 <!-- IRI also excludes the ranges U+E000 to U+F8FF, U+FFF0 to U+FFFD, and U+E0000 to U+E09FF, all
      inclusive. We don't to align with HTML. -->
 
-<p class=note>For historical reasons, rather than storing codepoints and [=percent-encoding=] to
-ASCII for serialization, URLs instead store their value as ASCII internally, eagerly converting
+<p class=note>For historical reasons, rather than storing codepoints and [=byte/percent-encoding=]
+to ASCII for serialization, URLs instead store their value as ASCII internally, eagerly converting
 code points greater than U+007F DELETE to [=percent-encoded bytes=] during [=URL parser|parsing=].
 
 <p class=note>In HTML, when the document encoding is a legacy encoding, code points in the

--- a/url.bs
+++ b/url.bs
@@ -2038,8 +2038,9 @@ and <a>code points</a> in the range U+00A0 to U+10FFFD, inclusive, excluding <a>
 <!-- IRI also excludes the ranges U+E000 to U+F8FF, U+FFF0 to U+FFFD, and U+E0000 to U+E09FF, all
      inclusive. We don't to align with HTML. -->
 
-<p class=note>Code points greater than U+007F DELETE will be converted to
-<a lt="percent-encoded byte">percent-encoded bytes</a> by the <a>URL parser</a>.
+<p class=note>For historical reasons, rather than storing codepoints and [=percent-encoding=] to
+ASCII for serialization, URLs instead store their value as ASCII internally, eagerly converting
+code points greater than U+007F DELETE to [=percent-encoded bytes=] during [=URL parser|parsing=].
 
 <p class=note>In HTML, when the document encoding is a legacy encoding, code points in the
 <a>URL-query string</a> that are higher than U+007F DELETE will be converted to


### PR DESCRIPTION
I didn't immediately realize the implications of this note and was *very* confused about how to handle the URL properly when doing some CSS work. I think this wording would have led me to the correct solution faster, so hopefully it'll help others.

(Note: I used a 100 character wrap, as that's what the rest of the spec appears to use. I also used Bikeshed'd `[=foo=]` syntax, but the rest of the spec seems to prefer explicit `<a>`s. I can switch if you want.)