### PR TITLE
Properly escape the &

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -3738,8 +3738,8 @@ url.searchParams.sort();
 console.log(url.href);   // "https://example.com/?a=b+%7E"</code></pre>
 
  <pre><code class="lang-javascript">
-const url = new URL('https://example.com/?a=~&b=%7E');
-console.log(url.search);                // "?a=~&b=%7E"
+const url = new URL('https://example.com/?a=~&amp;b=%7E');
+console.log(url.search);                // "?a=~&amp;b=%7E"
 console.log(url.searchParams.get('a')); // "~"
 console.log(url.searchParams.get('b')); // "~"</code></pre>
 


### PR DESCRIPTION
I'm about to cut a new release of Bikeshed, and it'll start complaining about the unescaped `&` in these two URLs (because they look like a `&b;` character escape, but without a final semicolon and with an unknown name). This is a parse error, [per the HTML spec](https://html.spec.whatwg.org/multipage/parsing.html#named-character-reference-state).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/808.html" title="Last updated on Dec 7, 2023, 10:22 PM UTC (e7cdb7e)">Preview</a> | <a href="https://whatpr.org/url/808/aa64bb2...e7cdb7e.html" title="Last updated on Dec 7, 2023, 10:22 PM UTC (e7cdb7e)">Diff</a>