### PR TITLE
Editorial: add a URL path concept

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1781,8 +1781,8 @@ the <a>blob URL store</a> between parsing and fetching, while fetching will stil
 
 <hr>
 
-<p>A <dfn export for=/>URL path</dfn> is either a <a>URL path segment</a> or a <a for=/>list</a> of
-zero or more <a>URL path segments</a>.
+<p>A <dfn export>URL path</dfn> is either a <a>URL path segment</a> or a <a for=/>list</a> of zero
+or more <a>URL path segments</a>.
 
 <p>A <dfn export>URL path segment</dfn> is an <a for=/>ASCII string</a>. It commonly refers to a
 directory or a file, but has no predefined meaning.

--- a/url.bs
+++ b/url.bs
@@ -1709,8 +1709,7 @@ null or a 16-bit unsigned integer that identifies a networking port. It is initi
 
 <p>A <a for=/>URL</a>'s
 <dfn export for=url id=concept-url-path oldids=non-relative-flag,url-cannot-be-a-base-url-flag>path</dfn>
-is either a <a>URL path segment</a> or a <a for=/>list</a> of zero or more <a>URL path segments</a>,
-usually identifying a location. It is initially « ».
+is a <a for=/>URL path</a>, usually identifying a location. It is initially « ».
 
 <p class=note>A <a lt="is special">special</a> <a for=/>URL</a>'s <a for=url>path</a> is always a
 <a for=/>list</a>, i.e., it is never <a for=url lt="opaque path">opaque</a>.
@@ -1781,6 +1780,9 @@ the <a>blob URL store</a> between parsing and fetching, while fetching will stil
 </div>
 
 <hr>
+
+<p>A <dfn export for=/>URL path</dfn> is either a <a>URL path segment</a> or a <a for=/>list</a> of
+zero or more <a>URL path segments</a>.
 
 <p>A <dfn export>URL path segment</dfn> is an <a for=/>ASCII string</a>. It commonly refers to a
 directory or a file, but has no predefined meaning.


### PR DESCRIPTION
This will be useful for a future version of the Cookies RFC.

Closes #792.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 26, 2024, 8:37 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Furl%2Fc9b5b18196386b2e3e8d82fcd37d2f0ec95d9b2d%2Furl.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20812)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/url%23812.)._
</details>
