### PR TITLE
Editorial: adopt Infra number definitions (and redo IPv6 pieces)

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -756,14 +756,14 @@ not equivalent and typically treated as distinct.
 
 <p>An <dfn export>IP address</dfn> is an <a>IPv4 address</a> or an <a>IPv6 address</a>.
 
-<p>An <dfn export id=concept-ipv4>IPv4 address</dfn> is a 32-bit unsigned integer that identifies a
-network address.
+<p>An <dfn export id=concept-ipv4>IPv4 address</dfn> is a <a for=/>32-bit unsigned integer</a> that
+identifies a network address.
 [[RFC791]]
 
-<p>An <dfn export id=concept-ipv6>IPv6 address</dfn> is a 128-bit unsigned integer that identifies a
-network address. For the purposes of this standard it is represented as a <a for=/>list</a> of eight
-16-bit unsigned integers, also known as
-<dfn export lt="IPv6 piece" id=concept-ipv6-piece>IPv6 pieces</dfn>.
+<p>An <dfn export id=concept-ipv6>IPv6 address</dfn> is a <a for=/>128-bit unsigned integer</a> that
+identifies a network address. For the purposes of this standard it is defined as of a
+<a for=/>list</a> of 8 <a for=/>16-bit unsigned integers</a>, also known as its
+<dfn export for="IPv6 address" id=concept-ipv6-piece>pieces</dfn>.
 [[RFC4291]]
 
 <p class="note">Support for <code>&lt;zone_id></code> is
@@ -1217,7 +1217,8 @@ these steps. They return failure or a <a for=/>tuple</a> of a number and a boole
 actually doing that with the editors of this document first.
 
 <ol>
- <li><p>Let <var>address</var> be a new <a>IPv6 address</a> whose <a>IPv6 pieces</a> are all 0.
+ <li><p>Let <var>address</var> be a new <a>IPv6 address</a> whose <a for="IPv6 address">pieces</a>
+ are all 0.
 
  <li><p>Let <var>pieceIndex</var> be 0.
 
@@ -1445,14 +1446,14 @@ actually doing that with the editors of this document first.
  <li><p>Let <var>output</var> be the empty string.
 
  <li>
-  <p>Let <var>compress</var> be an index to the first <a>IPv6 piece</a> in the first longest
-  sequences of <var>address</var>'s <a>IPv6 pieces</a> that are 0.
+  <p>Let <var>compress</var> be an index to the first item in the first longest sequences of
+  <var>address</var>'s <a for="IPv6 address">pieces</a> that are 0.
 
   <p class=example id=example-e2b3492e>In <code>0:f:0:0:f:f:0:0</code> it would point to
   the second 0.
 
- <li><p>If there is no sequence of <var>address</var>'s <a>IPv6 pieces</a> that are 0 that is
- longer than 1, then set <var>compress</var> to null.
+ <li><p>If there is no sequence of <var>address</var>'s <a for="IPv6 address">pieces</a> that are 0
+ that is longer than 1, then set <var>compress</var> to null.
 
  <li><p>Let <var>ignore0</var> be false.
 
@@ -1713,8 +1714,8 @@ It is initially the empty string.
  </table>
 </div>
 
-<p>A  <a for=/>URL</a>'s <dfn export for=url id=concept-url-port>port</dfn> is either
-null or a 16-bit unsigned integer that identifies a networking port. It is initially null.
+<p>A  <a for=/>URL</a>'s <dfn export for=url id=concept-url-port>port</dfn> is either null or a
+<a for=/>16-bit unsigned integer</a> that identifies a networking port. It is initially null.
 
 <p>A <a for=/>URL</a>'s
 <dfn export for=url id=concept-url-path oldids=non-relative-flag,url-cannot-be-a-base-url-flag>path</dfn>
@@ -1974,8 +1975,8 @@ followed by a <a>path-absolute-URL string</a>.
 
 <ul class=brief>
  <li><p>the empty string
- <li><p>one or more <a>ASCII digits</a> representing a decimal number no greater than
- 2<sup>16</sup>&nbsp;&minus;&nbsp;1.
+ <li><p>one or more <a>ASCII digits</a> representing a decimal number that is a
+ <a for=/>16-bit unsigned integer</a>.
 </ul>
 
 <p>A <dfn export oldids=syntax-url-scheme-relative>scheme-relative-URL string</dfn> must be
@@ -2577,7 +2578,7 @@ and then runs these steps:
          by <var>buffer</var> in radix-10 using <a>ASCII digits</a> for digits with values
          0 through 9.
 
-         <li><p>If <var>port</var> is greater than 2<sup>16</sup>&nbsp;&minus;&nbsp;1,
+         <li><p>If <var>port</var> is not a <a for=/>16-bit unsigned integer</a>,
          <a>port-out-of-range</a> <a>validation error</a>, return failure.
 
          <li><p>Set <var>url</var>'s <a for=url>port</a> to null, if <var>port</var> is

--- a/url.bs
+++ b/url.bs
@@ -761,8 +761,8 @@ identifies a network address.
 [[RFC791]]
 
 <p>An <dfn export id=concept-ipv6>IPv6 address</dfn> is a <a for=/>128-bit unsigned integer</a> that
-identifies a network address. For the purposes of this standard it is defined as of a
-<a for=/>list</a> of 8 <a for=/>16-bit unsigned integers</a>, also known as its
+identifies a network address. This integer is composed of a <a for=/>list</a> of 8
+<a for=/>16-bit unsigned integers</a>, also known as an <a for=/>IPv6 address</a>'s
 <dfn export for="IPv6 address" id=concept-ipv6-piece>pieces</dfn>.
 [[RFC4291]]
 
@@ -1445,15 +1445,15 @@ actually doing that with the editors of this document first.
 <ol>
  <li><p>Let <var>output</var> be the empty string.
 
+ <li><p>Let <var>compress</var> be null.
+
  <li>
-  <p>Let <var>compress</var> be an index to the first item in the first longest sequences of
+  <p>If multiple <var>address</var>'s <a for="IPv6 address">pieces</a> are 0 sequentially, then set
+  <var>compress</var> to the index of the first item of the first of the longest sequences of
   <var>address</var>'s <a for="IPv6 address">pieces</a> that are 0.
 
   <p class=example id=example-e2b3492e>In <code>0:f:0:0:f:f:0:0</code> it would point to
   the second 0.
-
- <li><p>If there is no sequence of <var>address</var>'s <a for="IPv6 address">pieces</a> that are 0
- that is longer than 1, then set <var>compress</var> to null.
 
  <li><p>Let <var>ignore0</var> be false.
 

--- a/url.bs
+++ b/url.bs
@@ -1445,20 +1445,14 @@ actually doing that with the editors of this document first.
 <ol>
  <li><p>Let <var>output</var> be the empty string.
 
- <li><p>Let <var>compress</var> be null.
-
- <li>
-  <p>If multiple <var>address</var>'s <a for="IPv6 address">pieces</a> are 0 sequentially, then set
-  <var>compress</var> to the index of the first item of the first of the longest sequences of
-  <var>address</var>'s <a for="IPv6 address">pieces</a> that are 0.
-
-  <p class=example id=example-e2b3492e>In <code>0:f:0:0:f:f:0:0</code> it would point to
-  the second 0.
+ <li><p>Let <var>compress</var> be the result of
+ <a for=/>finding the IPv6 address compressed piece index</a> given <var>address</var>.
 
  <li><p>Let <var>ignore0</var> be false.
 
  <li>
-  <p><a for=set>For each</a> <var>pieceIndex</var> in the range 0 to 7, inclusive:
+  <p><a for=set>For each</a> <var>pieceIndex</var> of <var>address</var>'s
+  <a for="IPv6 address">pieces</a>'s <a for=list>indices</a>:
 
   <ol>
    <li><p>If <var>ignore0</var> is true and <var>address</var>[<var>pieceIndex</var>] is 0, then
@@ -1470,8 +1464,8 @@ actually doing that with the editors of this document first.
     <p>If <var>compress</var> is <var>pieceIndex</var>, then:
 
     <ol>
-     <li><p>Let <var>separator</var> be "<code>::</code>" if <var>pieceIndex</var> is 0, and
-     U+003A (:) otherwise.
+     <li><p>Let <var>separator</var> be "<code>::</code>" if <var>pieceIndex</var> is 0; otherwise
+     U+003A (:).
 
      <li><p>Append <var>separator</var> to <var>output</var>.
 
@@ -1490,6 +1484,57 @@ actually doing that with the editors of this document first.
 <p class=note>This algorithm requires the recommendation from
 A Recommendation for IPv6 Address Text Representation.
 [[RFC5952]]
+</div>
+
+<div algorithm>
+<p>To <dfn>find the IPv6 address compressed piece index</dfn> given an <a for=/>IPv6 address</a>
+<var>address</var>:
+
+<ol>
+ <li><p>Let <var>longestIndex</var> be null.
+
+ <li><p>Let <var>longestSize</var> be 1.
+
+ <li><p>Let <var>foundIndex</var> be null.
+
+ <li><p>Let <var>foundSize</var> be 0.
+
+ <li>
+  <p><a for=list>For each</a> <var>pieceIndex</var> of <var>address</var>'s
+  <a for="IPv6 address">pieces</a>'s <a for=list>indices</a>:
+
+  <ol>
+   <li>
+    <p>If <var>address</var>'s <a for="IPv6 address">pieces</a>[<var>pieceIndex</var>] is not 0:
+
+    <ol>
+     <li><p>If <var>foundSize</var> is greater than <var>longestSize</var>, then set
+     <var>longestIndex</var> to <var>foundIndex</var> and <var>longestSize</var> to
+     <var>foundSize</var>.
+
+     <li>Set <var>foundIndex</var> to null.
+
+     <li>Set <var>foundSize</var> to 0.
+    </ol>
+
+   <li>
+    <p>Otherwise:
+
+    <ol>
+     <li><p>If <var>foundIndex</var> is null, then set <var>foundIndex</var> to
+     <var>pieceIndex</var>.
+
+     <li><p>Increment <var>foundSize</var> by 1.
+    </ol>
+  </ol>
+
+ <li><p>If <var>foundSize</var> is greater than <var>longestSize</var>, then return
+ <var>foundIndex</var>.
+
+ <li><p>Return <var>longestIndex</var>.
+</ol>
+
+<p class=example id=example-e2b3492e>In <code>0:f:0:0:f:f:0:0</code> it would point to the second 0.
 </div>
 
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/838.html" title="Last updated on Nov 25, 2024, 4:43 PM UTC (280ff43)">Preview</a> | <a href="https://whatpr.org/url/838/302c5af...280ff43.html" title="Last updated on Nov 25, 2024, 4:43 PM UTC (280ff43)">Diff</a>