### PR TITLE
Remove redundant domain to Unicode call from valid domain

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -952,20 +952,13 @@ concepts.
 <a>valid IPv4-address string</a>, or: U+005B ([), followed by a
 <a>valid IPv6-address string</a>, followed by U+005D (]).
 
-<p>A <var>domain</var> is a <dfn>valid domain</dfn> if these steps return success:
+<p>A <a for=/>string</a> <var>input</var> is a <dfn>valid domain</dfn> if these steps return true:
 
 <ol>
- <li><p>Let <var>result</var> be the result of running <a>domain to ASCII</a> with <var>domain</var>
+ <li><p>Let <var>domain</var> be the result of running <a>domain to ASCII</a> with <var>input</var>
  and true.
 
- <li><p>If <var>result</var> is failure, then return failure.
-
- <li><p>Set <var>result</var> to the result of running <a>domain to Unicode</a> with
- <var>result</var> and true.
-
- <li><p>If <var>result</var> contains any errors, return failure.
-
- <li><p>Return success.
+ <li><p>Return false if <var>domain</var> is failure; otherwise true.
 </ol>
 
 <p class=XXX>Ideally we define this in terms of a sequence of code points that make up a


### PR DESCRIPTION
I'm not entirely sure why this redundant check existed. Either because there was a difference back when this definition was introduced in 3bec3b89c4deb10842ba6c464c700df47c268f17 or (more likely) I wasn't sure if there was a difference.

Fixes #817.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/840.html" title="Last updated on Nov 29, 2024, 8:21 AM UTC (d0f8256)">Preview</a> | <a href="https://whatpr.org/url/840/7ff8de0...d0f8256.html" title="Last updated on Nov 29, 2024, 8:21 AM UTC (d0f8256)">Diff</a>