### PR TITLE
Set IDNA's CheckHyphens to the value of beStrict

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -906,7 +906,7 @@ concepts.
  <li>
   <p>Let <var>result</var> be the result of running <a abstract-op lt=ToASCII>Unicode ToASCII</a>
   with <i>domain_name</i> set to <var>domain</var>, <i>UseSTD3ASCIIRules</i> set to
-  <var>beStrict</var>, <i>CheckHyphens</i> set to false, <i>CheckBidi</i> set to true,
+  <var>beStrict</var>, <i>CheckHyphens</i> set to <var>beStrict</var>, <i>CheckBidi</i> set to true,
   <i>CheckJoiners</i> set to true, <i>Transitional_Processing</i> set to false,
   and <i>VerifyDnsLength</i> set to <var>beStrict</var>. [[!UTS46]]
 
@@ -936,9 +936,9 @@ concepts.
 <ol>
  <li><p>Let <var>result</var> be the result of running
  <a abstract-op lt=ToUnicode>Unicode ToUnicode</a> with <i>domain_name</i> set to <var>domain</var>,
- <i>CheckHyphens</i> set to false, <i>CheckBidi</i> set to true, <i>CheckJoiners</i> set to true,
- <i>UseSTD3ASCIIRules</i> set to <var>beStrict</var>, and <i>Transitional_Processing</i> set to
- false. [[!UTS46]]
+ <i>CheckHyphens</i> set to <var>beStrict</var>, <i>CheckBidi</i> set to true, <i>CheckJoiners</i>
+ set to true, <i>UseSTD3ASCIIRules</i> set to <var>beStrict</var>, and
+ <i>Transitional_Processing</i> set to false. [[!UTS46]]
 
  <li><p>Signify <a>domain-to-Unicode</a> <a>validation errors</a> for any returned errors, and then,
  return <var>result</var>.


### PR DESCRIPTION
It makes more sense if it's consistent with UseSTD3ASCIIRules and VerifyDnsLength.

Fixes #820.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/842.html" title="Last updated on Nov 29, 2024, 9:13 AM UTC (96bafa6)">Preview</a> | <a href="https://whatpr.org/url/842/7ff8de0...96bafa6.html" title="Last updated on Nov 29, 2024, 9:13 AM UTC (96bafa6)">Diff</a>