### PR TITLE
Editorial: only care about the empty string when beStrict is false

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -934,8 +934,12 @@ concepts.
     <a href="https://github.com/whatwg/url/issues/397">issue #397</a>.
   </ol>
 
- <li><p><a for=/>Assert</a>: <var>result</var> is not the empty string and does not contain a
- <a>forbidden domain code point</a>.
+ <li>
+  <p><a for=/>Assert</a>: <var>result</var> is not the empty string and does not contain a
+  <a>forbidden domain code point</a>.
+
+  <p class=note><cite>Unicode IDNA Compatibility Processing</cite> guarantees this holds when
+  <var>beStrict</var> is true. [[UTS46]]
 
  <li><p>Return <var>result</var>.
 </ol>

--- a/url.bs
+++ b/url.bs
@@ -917,19 +917,24 @@ concepts.
  <li><p>If <var>result</var> is a failure value, <a>domain-to-ASCII</a> <a>validation error</a>,
  return failure.
 
- <li><p>If <var>result</var> is the empty string, <a>domain-to-ASCII</a> <a>validation error</a>,
- return failure.
-
  <li>
-  <p>If <var>beStrict</var> is false and <var>result</var> contains a
-  <a>forbidden domain code point</a>, <a>domain-invalid-code-point</a> <a>validation error</a>,
-  return failure.
+  <p>If <var>beStrict</var> is false:
 
-  <p class=note>Due to web compatibility and compatibility with non-DNS-based systems the
-  <a>forbidden domain code points</a> are a subset of those disallowed when <i>UseSTD3ASCIIRules</i>
-  is true. See also <a href="https://github.com/whatwg/url/issues/397">issue #397</a>.
+  <ol>
+   <li><p>If <var>result</var> is the empty string, <a>domain-to-ASCII</a> <a>validation error</a>,
+   return failure.
 
- <li><p><a for=/>Assert</a>: <var>result</var> does not contain a
+   <li>
+    <p>If <var>result</var> contains a <a>forbidden domain code point</a>,
+    <a>domain-invalid-code-point</a> <a>validation error</a>, return failure.
+
+    <p class=note>Due to web compatibility and compatibility with non-DNS-based systems the
+    <a>forbidden domain code points</a> are a subset of those disallowed when
+    <i>UseSTD3ASCIIRules</i> is true. See also
+    <a href="https://github.com/whatwg/url/issues/397">issue #397</a>.
+  </ol>
+
+ <li><p><a for=/>Assert</a>: <var>result</var> is not the empty string and does not contain a
  <a>forbidden domain code point</a>.
 
  <li><p>Return <var>result</var>.


### PR DESCRIPTION
VerifyDnsLength will take care of it otherwise. (See #497 for additional context.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/845.html" title="Last updated on Dec 2, 2024, 4:08 PM UTC (d4110e0)">Preview</a> | <a href="https://whatpr.org/url/845/c3d173f...d4110e0.html" title="Last updated on Dec 2, 2024, 4:08 PM UTC (d4110e0)">Diff</a>