### PR TITLE
Add fast path to pathname start state

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2435,6 +2435,9 @@ and then runs these steps:
        <li><p>If <a>c</a> is U+005C (\), <a>invalid-reverse-solidus</a>
        <a>validation error</a>.
 
+       <li><p>If <a>c</a> is U+002F (/) and <a>c</a> is the last character in the state machine, then,
+       set <var>url</var>'s <var>path</var> to U+002F (/) and return <var>output</var>.
+
        <li><p>Set <var>state</var> to <a>special authority ignore slashes state</a>.
       </ol>
 


### PR DESCRIPTION
This particular change adds a fast-path for implementors. We already use this in Ada (available at https://github.com/ada-url/ada/blob/main/src/parser.cpp#L650).

This change removes the performance penalty of URLs ending with `/`. As someone can imagine, it's pretty common for a user to send a request to `https://ada-url.com/`.

This particular change improved the performance of Ada ~9-10%. https://github.com/ada-url/ada/pull/59


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url-whatwg/847.html" title="Last updated on Dec 9, 2024, 3:54 PM UTC (7962524)">Preview</a> | <a href="https://whatpr.org/url/847/7f3e3b6...7962524.html" title="Last updated on Dec 9, 2024, 3:54 PM UTC (7962524)">Diff</a>