### PR TITLE
Meta: correct dark mode .yesno styling

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -18,7 +18,7 @@ spec: UTS46; urlPrefix: https://www.unicode.org/reports/tr46/
 </pre>
 
 <style>
-.yesno .yes { background: papayawhip; }
+.yesno .yes { background: light-dark(papayawhip, midnightblue); color: light-dark(black, white); }
 .yesno .yes, .yesno .no { text-align: center; }
 </style>
 


### PR DESCRIPTION
This did not work correctly as pointed out here:
https://github.com/whatwg/url/issues/772#issuecomment-2702776864

---

@JamesNJep this looks pretty reasonable to me, but let me know if you prefer a different color.