### PR TITLE
Report all hostname state failures for URLPattern

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2538,7 +2538,7 @@ and then runs these steps:
      <a>file host state</a>.
 
      <li>
-      <p>Otherwise, if <a>c</a> is U+003A (:) and <var>insideBrackets</var> is false, then:
+      <p>Otherwise, if <a>c</a> is U+003A (:) and <var>insideBrackets</var> is false:
 
       <ol>
        <li><p>If <var>buffer</var> is the empty string, <a>host-missing</a> <a>validation error</a>,
@@ -2546,7 +2546,7 @@ and then runs these steps:
        <!-- No URLs with port, but without host. -->
 
        <li><p>If <var>state override</var> is given and <var>state override</var> is
-       <a>hostname state</a>, then return.
+       <a>hostname state</a>, then return failure.
 
        <li><p>Let <var>host</var> be the result of <a>host parsing</a> <var>buffer</var> with
        <var>url</var> <a>is not special</a>.
@@ -2566,7 +2566,7 @@ and then runs these steps:
        <li><p><var>url</var> <a>is special</a> and <a>c</a> is U+005C (\)
       </ul>
 
-      <p>then decrease <var>pointer</var> by 1, and then:
+      <p>then decrease <var>pointer</var> by 1, and:
 
       <ol>
        <li><p>If <var>url</var> <a>is special</a> and <var>buffer</var> is the empty string,
@@ -2576,7 +2576,7 @@ and then runs these steps:
 
        <li><p>Otherwise, if <var>state override</var> is given, <var>buffer</var> is the empty
        string, and either <var>url</var> <a>includes credentials</a> or <var>url</var>'s
-       <a for=url>port</a> is non-null, return.
+       <a for=url>port</a> is non-null, then return failure.
        <!-- API validation error -->
 
        <li><p>Let <var>host</var> be the result of <a>host parsing</a> <var>buffer</var> with

--- a/url.bs
+++ b/url.bs
@@ -2547,6 +2547,7 @@ and then runs these steps:
 
        <li><p>If <var>state override</var> is given and <var>state override</var> is
        <a>hostname state</a>, then return failure.
+       <!-- API validation error -->
 
        <li><p>Let <var>host</var> be the result of <a>host parsing</a> <var>buffer</var> with
        <var>url</var> <a>is not special</a>.


### PR DESCRIPTION
URLPattern's canonicalize a hostname is the only invocation of the basic URL parser with a URL and state override set to hostname state that looks at the return failure.

And since the URL that URLPattern uses is a dummy URL that is ideally not exposed, knowing about all the failure conditions is kind of important.

(Now technically the second return failure added here cannot be observed as the dummy URL won't have credentials or a non-null port, but it seemed good to change that at the same time for consistency.)

This is covered by existing URLPattern web-platform-tests. Some more background can be found in https://github.com/whatwg/urlpattern/issues/252.

<!--
Thank you for contributing to the URL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Required by URLPattern.
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * URLPattern tests.
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A, to be filed as part of URLPattern changes.
   * Gecko: N/A, to be filed as part of URLPattern changes.
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=289401
   * Deno: N/A, to be filed as part of URLPattern changes.
   * Node.js: N/A, to be filed as part of URLPattern changes.
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/863.html" title="Last updated on Mar 19, 2025, 10:25 PM UTC (7c15b77)">Preview</a> | <a href="https://whatpr.org/url/863/076afff...7c15b77.html" title="Last updated on Mar 19, 2025, 10:25 PM UTC (7c15b77)">Diff</a>