### PR TITLE
Editorial: Use code unit less than algorithm for URLSearchParams sort

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -4061,7 +4061,8 @@ sorted.sort()</code></pre>
 <p>The <dfn method for=URLSearchParams><code>sort()</code></dfn> method steps are:
 
 <ol>
- <li><p><a for=list>Sort in ascending order</a> <a>this</a>'s <a for=URLSearchParams>list</a>,
+ <li><p>Set <a>this</a>'s <a for=URLSearchParams>list</a> to the result of
+ <a for=list>sorting in ascending order</a> <a>this</a>'s <a for=URLSearchParams>list</a>,
  with |a| being less than |b| if |a|'s name is <a>code unit less than</a> |b|'s name.
 
  <li><p><a for=URLSearchParams>Update</a> <a>this</a>.

--- a/url.bs
+++ b/url.bs
@@ -4062,8 +4062,8 @@ sorted.sort()</code></pre>
 
 <ol>
  <li><p>Sort all <a for=/>tuples</a> in <a>this</a>'s <a for=URLSearchParams>list</a>, if any, by
- their names. Sorting must be done by comparison of code units. The relative order between
- <a for=/>tuples</a> with equal names must be preserved.
+ their names. Sorting must be done using the <a>code unit less than</a> algorithm. The relative
+ order between <a for=/>tuples</a> with equal names must be preserved.
 
  <li><p><a for=URLSearchParams>Update</a> <a>this</a>.
 </ol>

--- a/url.bs
+++ b/url.bs
@@ -4061,9 +4061,8 @@ sorted.sort()</code></pre>
 <p>The <dfn method for=URLSearchParams><code>sort()</code></dfn> method steps are:
 
 <ol>
- <li><p>Sort all <a for=/>tuples</a> in <a>this</a>'s <a for=URLSearchParams>list</a>, if any, by
- their names. Sorting must be done using the <a>code unit less than</a> algorithm. The relative
- order between <a for=/>tuples</a> with equal names must be preserved.
+ <li><p><a for=list>Sort in ascending order</a> <a>this</a>'s <a for=URLSearchParams>list</a>,
+ with |a| being less than |b| if |a|'s name is <a>code unit less than</a> |b|'s name.
 
  <li><p><a for=URLSearchParams>Update</a> <a>this</a>.
 </ol>


### PR DESCRIPTION
I noticed this algorithm in the infra spec, and I believe this is what all engines already do for the sort.

Hopefully not mistaken!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/872.html" title="Last updated on May 12, 2025, 7:54 AM UTC (216797e)">Preview</a> | <a href="https://whatpr.org/url/872/cc8b776...216797e.html" title="Last updated on May 12, 2025, 7:54 AM UTC (216797e)">Diff</a>