### PR TITLE
Simplify the public suffix and registrable domain definitions

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -794,8 +794,8 @@ that is included on the <cite>Public Suffix List</cite>. [[!PSL]]
  <a href="https://github.com/publicsuffix/list/wiki/Format#formal-algorithm">Public Suffix List algorithm</a>
  with <var>host</var> as domain. [[!PSL]]
 
- <li><p>Assert: <var>publicSuffix</var> is an <a>ASCII string</a> that <a for=string>ends with</a>
- <var>trailingDot</var>.
+ <li><p><a for=/>Assert</a>: <var>publicSuffix</var> is an <a>ASCII string</a> that
+ <a for=string>ends with</a> <var>trailingDot</var>.
 
  <li><p>Return <var>publicSuffix</var>.
 </ol>
@@ -818,7 +818,7 @@ any.
  <a href="https://github.com/publicsuffix/list/wiki/Format#formal-algorithm">Public Suffix List algorithm</a>
  with <var>host</var> as domain. [[!PSL]]
 
- <li><p>Assert: <var>registrableDomain</var> is an <a>ASCII string</a> that
+ <li><p><a for=/>Assert</a>: <var>registrableDomain</var> is an <a>ASCII string</a> that
  <a for=string>ends with</a> <var>trailingDot</var>.
 
  <li><p>Return <var>registrableDomain</var>.


### PR DESCRIPTION
As of April 1, 2025, the Public Suffix List algorithm was modified so that the trailing dot of a domain would be retained in the result. Quotes from [this algorithm](https://github.com/publicsuffix/list/wiki/Format#formal-algorithm):

> * The public suffix is the set of labels from the domain which match the labels of the prevailing rule, using the matching algorithm above. A trailing dot shall be added if the domain included one. (See Note 3)

>  **Note 3**
> Callers of the algorithm often cannot determine if the domain to be queried is an FQDN but may treat `example.com` and `example.com.` as distinct. To support this, the algorithm should retain that distinction. This means looking up `example.com` should yield `com` while looking up `example.com.` should yield `com.` as the public suffix.

Therefore, there is no need to add a trailing dot to the result if the input domain has one, as this dot is retained by the PSL algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/887.html" title="Last updated on Oct 30, 2025, 7:36 AM UTC (e8a672b)">Preview</a> | <a href="https://whatpr.org/url/887/05a5d83...e8a672b.html" title="Last updated on Oct 30, 2025, 7:36 AM UTC (e8a672b)">Diff</a>