### PR TITLE
Editorial: Add missing article before "hexadecimal number"

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -418,7 +418,7 @@ bytes that are not <a>ASCII bytes</a> might be insecure and is not recommended.
 
     <ol>
      <li><p>Let <var>bytePoint</var> be the two bytes after <var>byte</var> in <var>input</var>,
-     <a lt="isomorphic decode">decoded</a>, and then interpreted as hexadecimal number.
+     <a lt="isomorphic decode">decoded</a>, and then interpreted as a hexadecimal number.
      <!-- We should have a better definition for this. -->
 
      <li><p>Append a byte whose value is <var>bytePoint</var> to
@@ -1280,7 +1280,7 @@ actually doing that with the editors of this document first.
    <li><p>Let <var>value</var> and <var>length</var> be 0.
 
    <li><p>While <var>length</var> is less than 4 and <a>c</a> is an <a>ASCII hex digit</a>, set
-   <var>value</var> to <var>value</var> &times; 0x10 + <a>c</a> interpreted as hexadecimal number,
+   <var>value</var> to <var>value</var> &times; 0x10 + <a>c</a> interpreted as a hexadecimal number,
    and increase <var>pointer</var> and <var>length</var> by 1.
 
    <li>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/906.html" title="Last updated on Apr 18, 2026, 9:36 AM UTC (a9a2a65)">Preview</a> | <a href="https://whatpr.org/url/906/b11d73b...a9a2a65.html" title="Last updated on Apr 18, 2026, 9:36 AM UTC (a9a2a65)">Diff</a>