### PR TITLE
Fix extra space in query definition

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1788,7 +1788,7 @@ is a <a for=/>URL path</a>, usually identifying a location. It is initially Â« Â
 <p class=note>A <a lt="is special">special</a> <a for=/>URL</a>'s <a for=url>path</a> is always a
 <a for=/>list</a>, i.e., it is never <a for=url lt="opaque path">opaque</a>.
 
-<p>A  <a for=/>URL</a>'s <dfn export for=url id=concept-url-query>query</dfn> is either
+<p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-query>query</dfn> is either
 null or an <a>ASCII string</a>. It is initially null.
 
 <p>A <a for=/>URL</a>'s <dfn export for=url id=concept-url-fragment>fragment</dfn> is either null or


### PR DESCRIPTION
Noticed the query definition had a double space between "A" and the <a> tag, same as the port definition that was fixed in b11d73b. Looks like it was just missed. All the other URL component definitions (scheme, username, password, host, path, fragment) have a single space there, so this makes it consistent.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/910.html" title="Last updated on May 31, 2026, 1:51 AM UTC (a460987)">Preview</a> | <a href="https://whatpr.org/url/910/91c807f...a460987.html" title="Last updated on May 31, 2026, 1:51 AM UTC (a460987)">Diff</a>