### PR TITLE
Editorial: fix minor markup and grammar issues in url.bs

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -2161,7 +2161,7 @@ different document encoding. Using the <a>UTF-8</a> encoding everywhere solves t
 
 <p class=note>How user input in the web browser's address bar is converted to a
 <a for=/>URL record</a> is out-of-scope of this standard. This standard does include
-<a href="#url-rendering">URL rendering requirements</a> as they pertain trust decisions.
+<a href="#url-rendering">URL rendering requirements</a> as they pertain to trust decisions.
 
 <ol>
  <li><p>Let <var>url</var> be the result of running the <a>basic URL parser</a> on <var>input</var>
@@ -3004,7 +3004,7 @@ and then runs these steps:
        <li><p>Set <var>buffer</var> to the empty string.
 
        <li><p>If <a>c</a> is U+0023 (#), then set <var>url</var>'s <a for=url>fragment</a> to
-       the empty string and state to <a>fragment state</a>.
+       the empty string and <var>state</var> to <a>fragment state</a>.
       </ol>
 
      <li>
@@ -3753,7 +3753,7 @@ one might have assumed the setter to always "reset" both.
  return.
 
  <li><p>If the given value is the empty string, then set <a>this</a>'s <a for=URL>URL</a>'s
- <a for=url>port</a> to null.</p></li>
+ <a for=url>port</a> to null.
 
  <li><p>Otherwise, <a lt="basic URL parser">basic URL parse</a> the given value with
  <a>this</a>'s <a for=URL>URL</a> as <a for="basic URL parser"><i>url</i></a> and


### PR DESCRIPTION
Small editorial cleanup while reading through the spec. Fixed a missing word ("pertain to" instead of "pertain") in the URL parsing note, clarified the fragment state assignment by naming the variable explicitly, and closed an unterminated </p></li> in the URL class port setter.
Nothing functional changed, just wording and markup consistency.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/911.html" title="Last updated on Jun 3, 2026, 4:23 PM UTC (8db596f)">Preview</a> | <a href="https://whatpr.org/url/911/afc0820...8db596f.html" title="Last updated on Jun 3, 2026, 4:23 PM UTC (8db596f)">Diff</a>