### PR TITLE
Remove duplicate "Alexis Hunt" from acknowledgments

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -4130,8 +4130,8 @@ Adrián Chaves,<!-- Gallaecio; GitHub -->
 Adrien Ricciardi,
 Albert Wiersch,
 Alex Christensen,
-Alexis Hunt,<!-- alercah; GitHub -->
 Alexandre Morgaut,
+Alexis Hunt,<!-- alercah; GitHub -->
 Alwin Blok,
 Andrew Sullivan,
 Arkadiusz Michalski,

--- a/url.bs
+++ b/url.bs
@@ -4132,7 +4132,6 @@ Albert Wiersch,
 Alex Christensen,
 Alexis Hunt,<!-- alercah; GitHub -->
 Alexandre Morgaut,
-Alexis Hunt,
 Alwin Blok,
 Andrew Sullivan,
 Arkadiusz Michalski,


### PR DESCRIPTION
While going through the acknowledgments section I noticed "Alexis Hunt" is listed twice, once with the GitHub handle comment and once without. Removed the duplicate.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/912.html" title="Last updated on Jun 4, 2026, 11:45 AM UTC (183d7b4)">Preview</a> | <a href="https://whatpr.org/url/912/6d83609...183d7b4.html" title="Last updated on Jun 4, 2026, 11:45 AM UTC (183d7b4)">Diff</a>