### PR TITLE
Add Unicode ToASCII fallback for ASCII domains

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -912,10 +912,26 @@ concepts.
 <var>domain</var> and a boolean <var>beStrict</var>, runs these steps:
 
 <ol>
+ <li>
+  <p>If <var>beStrict</var> is true:
+
+  <ol>
+   <li><p>Let <var>result</var> be the result of running
+   <a abstract-op lt=ToASCII>Unicode ToASCII</a> with <i>domain_name</i> set to <var>domain</var>,
+   <i>CheckHyphens</i> set to true, <i>CheckBidi</i> set to true, <i>CheckJoiners</i> set to true,
+   <i>UseSTD3ASCIIRules</i> set to true, <i>Transitional_Processing</i> set to false,
+   <i>VerifyDnsLength</i> set to true, and <i>IgnoreInvalidPunycode</i> set to false. [[!UTS46]]
+
+   <li><p>If <var>result</var> is a failure value, <a>domain-to-ASCII</a> <a>validation error</a>,
+   return failure.
+
+   <li><p>Return <var>result</var>.
+  </ol>
+
  <li><p>Let <var>result</var> be null.
 
  <li>
-  <p>If <var>beStrict</var> is false and <var>domain</var> is an <a>ASCII string</a>:
+  <p>If <var>domain</var> is an <a>ASCII string</a>:
 
   <ol>
    <li><p>If running <a abstract-op lt=ToASCII>Unicode ToASCII</a> with <i>domain_name</i> set to
@@ -928,8 +944,9 @@ concepts.
    <li><p>Set <var>result</var> to <var>domain</var>, <a lt="ASCII lowercase">lowercased</a>.
   </ol>
 
-  <p class=note>Due to web compatibility <a abstract-op lt=ToASCII>Unicode ToASCII</a> only records
-  <a>validation errors</a> when <var>domain</var> is an <a>ASCII string</a>.
+  <p class=note>When <var>beStrict</var> is false and <var>domain</var> is an <a>ASCII string</a>,
+  <a abstract-op lt=ToASCII>Unicode ToASCII</a> failures only result in <a>validation errors</a>
+  (instead of failing the whole algorithm) due to web compatibility.
 
  <li>
   <p>Otherwise:
@@ -937,38 +954,24 @@ concepts.
   <ol>
    <li><p>Set <var>result</var> to the result of running
    <a abstract-op lt=ToASCII>Unicode ToASCII</a> with <i>domain_name</i> set to <var>domain</var>,
-   <i>CheckHyphens</i> set to <var>beStrict</var>, <i>CheckBidi</i> set to true,
-   <i>CheckJoiners</i> set to true, <i>UseSTD3ASCIIRules</i> set to <var>beStrict</var>,
-   <i>Transitional_Processing</i> set to false, <i>VerifyDnsLength</i> set to <var>beStrict</var>,
-   and <i>IgnoreInvalidPunycode</i> set to false. [[!UTS46]]
+   <i>CheckHyphens</i> set to false, <i>CheckBidi</i> set to true, <i>CheckJoiners</i> set to true,
+   <i>UseSTD3ASCIIRules</i> set to false, <i>Transitional_Processing</i> set to false,
+   <i>VerifyDnsLength</i> set to false, and <i>IgnoreInvalidPunycode</i> set to false. [[!UTS46]]
 
    <li><p>If <var>result</var> is a failure value, <a>domain-to-ASCII</a> <a>validation error</a>,
    return failure.
   </ol>
 
- <li>
-  <p>If <var>beStrict</var> is false:
-
-  <ol>
-   <li><p>If <var>result</var> is the empty string, <a>domain-to-ASCII</a> <a>validation error</a>,
-   return failure.
-
-   <li>
-    <p>If <var>result</var> contains a <a>forbidden domain code point</a>,
-    <a>domain-invalid-code-point</a> <a>validation error</a>, return failure.
-
-    <p class=note>Due to web compatibility and compatibility with non-DNS-based systems the
-    <a>forbidden domain code points</a> are a subset of those disallowed when
-    <i>UseSTD3ASCIIRules</i> is true. See also
-    <a href="https://github.com/whatwg/url/issues/397">issue #397</a>.
-  </ol>
+ <li><p>If <var>result</var> is the empty string, <a>domain-to-ASCII</a> <a>validation error</a>,
+ return failure.
 
  <li>
-  <p><a for=/>Assert</a>: <var>result</var> is not the empty string and does not contain a
-  <a>forbidden domain code point</a>.
+  <p>If <var>result</var> contains a <a>forbidden domain code point</a>,
+  <a>domain-invalid-code-point</a> <a>validation error</a>, return failure.
 
-  <p class=note><cite>Unicode IDNA Compatibility Processing</cite> guarantees this holds when
-  <var>beStrict</var> is true. [[UTS46]]
+  <p class=note>Due to web compatibility and compatibility with non-DNS-based systems the
+  <a>forbidden domain code points</a> are a subset of those disallowed when <i>UseSTD3ASCIIRules</i>
+  is true. See also <a href="https://github.com/whatwg/url/issues/397">issue #397</a>.
 
  <li><p>Return <var>result</var>.
 </ol>

--- a/url.bs
+++ b/url.bs
@@ -111,7 +111,7 @@ valid input. User agents, especially conformance checkers, are encouraged to rep
     [[UTS46]]
     <p class=note>If details about <a abstract-op lt=ToASCII>Unicode ToASCII</a> errors are
     recorded, user agents are encouraged to pass those along.
-   <td class=yes>Yes
+   <td class=yes>Yes<br>(unless <var>domain</var> is an <a>ASCII string</a>)
   <tr>
    <td><dfn>domain-invalid-code-point</dfn>
    <td>
@@ -912,20 +912,24 @@ concepts.
 <var>domain</var> and a boolean <var>beStrict</var>, runs these steps:
 
 <ol>
+ <li><p>Let <var>result</var> be the result of running
+ <a abstract-op lt=ToASCII>Unicode ToASCII</a> with <i>domain_name</i> set to <var>domain</var>,
+ <i>CheckHyphens</i> set to <var>beStrict</var>, <i>CheckBidi</i> set to true, <i>CheckJoiners</i>
+ set to true, <i>UseSTD3ASCIIRules</i> set to <var>beStrict</var>, <i>Transitional_Processing</i>
+ set to false, <i>VerifyDnsLength</i> set to <var>beStrict</var>, and <i>IgnoreInvalidPunycode</i>
+ set to false. [[!UTS46]]
+
  <li>
-  <p>Let <var>result</var> be the result of running <a abstract-op lt=ToASCII>Unicode ToASCII</a>
-  with <i>domain_name</i> set to <var>domain</var>, <i>CheckHyphens</i> set to <var>beStrict</var>,
-  <i>CheckBidi</i> set to true, <i>CheckJoiners</i> set to true, <i>UseSTD3ASCIIRules</i> set to
-  <var>beStrict</var>, <i>Transitional_Processing</i> set to false, <i>VerifyDnsLength</i> set to
-  <var>beStrict</var>, and <i>IgnoreInvalidPunycode</i> set to false. [[!UTS46]]
+  <p>If <var>result</var> is a failure value:
 
-  <p class=note>If <var>beStrict</var> is false, <var>domain</var> is an <a>ASCII string</a>, and
-  <a>strictly splitting</a> <var>domain</var> on U+002E (.) does not produce any
-  <a for=list>item</a> that <a for=string>starts with</a> an <a>ASCII case-insensitive</a> match for
-  "<code>xn--</code>", this step is equivalent to <a>ASCII lowercasing</a> <var>domain</var>.
+  <ol>
+   <li><p><a>domain-to-ASCII</a> <a>validation error</a>.
 
- <li><p>If <var>result</var> is a failure value, <a>domain-to-ASCII</a> <a>validation error</a>,
- return failure.
+   <li><p>If <var>beStrict</var> is false and <var>domain</var> is an <a>ASCII string</a>, then set
+   <var>result</var> to <var>domain</var>, <a lt="ASCII lowercase">lowercased</a>.
+
+   <li><p>Otherwise, return failure.
+  </ol>
 
  <li>
   <p>If <var>beStrict</var> is false:
@@ -953,6 +957,10 @@ concepts.
 
  <li><p>Return <var>result</var>.
 </ol>
+
+<p class=note>If <var>beStrict</var> is false and <var>domain</var> is an <a>ASCII string</a>, this
+algorithm is effectively <a lt="ASCII lowercase">ASCII lowercasing</a> <var>domain</var> and
+checking the result for <a>forbidden domain code points</a>. This is done for web compatibility.
 
 <p class=note>This document and the web platform at large use
 <cite>Unicode IDNA Compatibility Processing</cite> and not IDNA2008. For instance,

--- a/url.bs
+++ b/url.bs
@@ -946,7 +946,10 @@ concepts.
 
   <p class=note>When <var>beStrict</var> is false and <var>domain</var> is an <a>ASCII string</a>,
   <a abstract-op lt=ToASCII>Unicode ToASCII</a> failures only result in <a>validation errors</a>
-  (instead of failing the whole algorithm) due to web compatibility.
+  (instead of failing the whole algorithm) due to web compatibility. <i>IgnoreInvalidPunycode</i>
+  is not sufficient on its own, as Punycode can decode successfully yet still fail validity
+  criteria. E.g., <code>xn--8i7caa</code> decodes to <code>ｗｗｗ</code>, whose code points have
+  status "mapped". [[UTS46]]
 
  <li>
   <p>Otherwise:

--- a/url.bs
+++ b/url.bs
@@ -912,23 +912,38 @@ concepts.
 <var>domain</var> and a boolean <var>beStrict</var>, runs these steps:
 
 <ol>
- <li><p>Let <var>result</var> be the result of running
- <a abstract-op lt=ToASCII>Unicode ToASCII</a> with <i>domain_name</i> set to <var>domain</var>,
- <i>CheckHyphens</i> set to <var>beStrict</var>, <i>CheckBidi</i> set to true, <i>CheckJoiners</i>
- set to true, <i>UseSTD3ASCIIRules</i> set to <var>beStrict</var>, <i>Transitional_Processing</i>
- set to false, <i>VerifyDnsLength</i> set to <var>beStrict</var>, and <i>IgnoreInvalidPunycode</i>
- set to false. [[!UTS46]]
+ <li><p>Let <var>result</var> be null.
 
  <li>
-  <p>If <var>result</var> is a failure value:
+  <p>If <var>beStrict</var> is false and <var>domain</var> is an <a>ASCII string</a>:
 
   <ol>
-   <li><p><a>domain-to-ASCII</a> <a>validation error</a>.
+   <li><p>If running <a abstract-op lt=ToASCII>Unicode ToASCII</a> with <i>domain_name</i> set to
+   <var>domain</var>, <i>CheckHyphens</i> set to false, <i>CheckBidi</i> set to true,
+   <i>CheckJoiners</i> set to true, <i>UseSTD3ASCIIRules</i> set to false,
+   <i>Transitional_Processing</i> set to false, <i>VerifyDnsLength</i> set to false, and
+   <i>IgnoreInvalidPunycode</i> set to false is a failure value, <a>domain-to-ASCII</a>
+   <a>validation error</a>. [[!UTS46]]
 
-   <li><p>If <var>beStrict</var> is false and <var>domain</var> is an <a>ASCII string</a>, then set
-   <var>result</var> to <var>domain</var>, <a lt="ASCII lowercase">lowercased</a>.
+   <li><p>Set <var>result</var> to <var>domain</var>, <a lt="ASCII lowercase">lowercased</a>.
+  </ol>
 
-   <li><p>Otherwise, return failure.
+  <p class=note>Due to web compatibility <a abstract-op lt=ToASCII>Unicode ToASCII</a> only records
+  <a>validation errors</a> when <var>domain</var> is an <a>ASCII string</a>.
+
+ <li>
+  <p>Otherwise:
+
+  <ol>
+   <li><p>Set <var>result</var> to the result of running
+   <a abstract-op lt=ToASCII>Unicode ToASCII</a> with <i>domain_name</i> set to <var>domain</var>,
+   <i>CheckHyphens</i> set to <var>beStrict</var>, <i>CheckBidi</i> set to true,
+   <i>CheckJoiners</i> set to true, <i>UseSTD3ASCIIRules</i> set to <var>beStrict</var>,
+   <i>Transitional_Processing</i> set to false, <i>VerifyDnsLength</i> set to <var>beStrict</var>,
+   and <i>IgnoreInvalidPunycode</i> set to false. [[!UTS46]]
+
+   <li><p>If <var>result</var> is a failure value, <a>domain-to-ASCII</a> <a>validation error</a>,
+   return failure.
   </ol>
 
  <li>
@@ -957,10 +972,6 @@ concepts.
 
  <li><p>Return <var>result</var>.
 </ol>
-
-<p class=note>If <var>beStrict</var> is false and <var>domain</var> is an <a>ASCII string</a>, this
-algorithm is effectively <a lt="ASCII lowercase">ASCII lowercasing</a> <var>domain</var> and
-checking the result for <a>forbidden domain code points</a>. This is done for web compatibility.
 
 <p class=note>This document and the web platform at large use
 <cite>Unicode IDNA Compatibility Processing</cite> and not IDNA2008. For instance,


### PR DESCRIPTION
Unfortunately implementing Unicode ToASCII ends up rejecting websites such as

- http://xn--72czcrhaj7cpt0ed1dxb4mb1s1.blogspot.com/2018/11/blog-post_60.html
- https://xn--8i7caa.famitei.net/sekou/all
- https://xn--board-ngr.palungjit.org/members/

which is not really acceptable. So when ToASCII fails, domain is all ASCII, and there are no forbidden domain code points, we just return the lowercased domain. If an implementation does not surface validation errors this is indistinguishable from having an ASCII fast path.

Tests: https://github.com/web-platform-tests/wpt/pull/60476

<!--
Thank you for contributing to the URL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Chromium presumably
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * See commit message.
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: …
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=316554
   * Deno: …
   * Node.js: …
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/url/914.html" title="Last updated on Jun 17, 2026, 2:49 PM UTC (9b998f7)">Preview</a> | <a href="https://whatpr.org/url/914/9fe73be...9b998f7.html" title="Last updated on Jun 17, 2026, 2:49 PM UTC (9b998f7)">Diff</a>